### PR TITLE
Fix InvalidArgumentException

### DIFF
--- a/src/FeedIo/Rule/Description.php
+++ b/src/FeedIo/Rule/Description.php
@@ -23,7 +23,7 @@ class Description extends RuleAbstract
     public function setProperty(NodeInterface $node, \DOMElement $element)
     {
         $string = '';
-        if ( $element->firstChild->nodeType == XML_CDATA_SECTION_NODE ) {
+        if ( $element->firstChild && $element->firstChild->nodeType == XML_CDATA_SECTION_NODE ) {
             $string = $element->firstChild->textContent;
         } else {
             foreach($element->childNodes as $childNode) {


### PR DESCRIPTION
Fix this Exception when the feed description tag is empty:
```
InvalidArgumentException: malformed xml string. parsing error : Trying to get property of non-object (8) in /vendor/debril/feed-io/src/FeedIo/Reader.php:95
Stack trace:
#0 vendor/debril/feed-io/src/FeedIo/Rule/Description.php(26): FeedIo\Reader->FeedIo\{closure}(8, 'Trying to get p...', '...', 26, Array)
```