### PR TITLE
Refactor node and element implement a ElementsAwareInterface interface for type checking

### DIFF
--- a/src/FeedIo/Feed/ElementsAwareInterface.php
+++ b/src/FeedIo/Feed/ElementsAwareInterface.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed;
+
+use FeedIo\Feed\Node\ElementInterface;
+use FeedIo\Feed\Node\ElementIterator;
+
+interface ElementsAwareInterface
+{
+    /**
+     * @return ElementInterface
+     */
+    public function newElement();
+
+    /**
+     * @param  string $name element name
+     * @return ElementIterator
+     */
+    public function getElementIterator($name);
+
+    /**
+     * @param  string $name element name
+     * @return boolean true if the element exists
+     */
+    public function hasElement($name);
+
+    /**
+     * @param  ElementInterface $element
+     * @return $this
+     */
+    public function addElement(ElementInterface $element);
+
+    /**
+     * Returns all the item's optional elements
+     * @return \ArrayIterator
+     */
+    public function getAllElements();
+
+    /**
+     * Returns the item's optional elements tag names
+     * @return array
+     */
+    public function listElements();
+
+    /**
+     * @return \Generator
+     */
+    public function getElementsGenerator();
+}

--- a/src/FeedIo/Feed/ElementsAwareTrait.php
+++ b/src/FeedIo/Feed/ElementsAwareTrait.php
@@ -39,19 +39,6 @@ trait ElementsAwareTrait
 
     /**
      * @param  string $name element name
-     * @return mixed
-     */
-    public function getValue($name)
-    {
-        foreach ($this->getElementIterator($name) as $element) {
-            return $element->getValue();
-        }
-
-        return;
-    }
-
-    /**
-     * @param  string $name element name
      * @return ElementIterator
      */
     public function getElementIterator($name)

--- a/src/FeedIo/Feed/Node.php
+++ b/src/FeedIo/Feed/Node.php
@@ -13,10 +13,10 @@ namespace FeedIo\Feed;
 use FeedIo\Feed\Node\Category;
 use FeedIo\Feed\Node\CategoryInterface;
 
-class Node implements NodeInterface
+class Node implements NodeInterface, ElementsAwareInterface
 {
     use ElementsAwareTrait;
-    
+
     /**
      * @var \ArrayIterator
      */
@@ -206,6 +206,19 @@ class Node implements NodeInterface
         $this->link = $link;
 
         return $this;
+    }
+
+    /**
+     * @param  string $name element name
+     * @return mixed
+     */
+    public function getValue($name)
+    {
+        foreach ($this->getElementIterator($name) as $element) {
+            return $element->getValue();
+        }
+
+        return;
     }
 
     /**

--- a/src/FeedIo/Feed/Node/Element.php
+++ b/src/FeedIo/Feed/Node/Element.php
@@ -10,9 +10,10 @@
 
 namespace FeedIo\Feed\Node;
 
+use FeedIo\Feed\ElementsAwareInterface;
 use FeedIo\Feed\ElementsAwareTrait;
 
-class Element implements ElementInterface
+class Element implements ElementInterface, ElementsAwareInterface
 {
     use ElementsAwareTrait;
 

--- a/src/FeedIo/Feed/Node/ElementInterface.php
+++ b/src/FeedIo/Feed/Node/ElementInterface.php
@@ -73,42 +73,4 @@ interface ElementInterface
      * @return $this
      */
     public function setAttribute($name, $value);
-
-    /**
-     * returns the ElementIterator to iterate over ElementInterface instances called $name
-     *
-     * @param  string $name element name
-     * @return \FeedIo\Feed\Node\ElementIterator
-     */
-    public function getElementIterator($name);
-
-    /**
-     * returns true if an ElementInterface instance called $name exists
-     *
-     * @param  string $name element name
-     * @return boolean true if the element exists
-     */
-    public function hasElement($name);
-
-    /**
-     * adds $element to the object's attributes
-     *
-     * @param  ElementInterface $element
-     * @return $this
-     */
-    public function addElement(ElementInterface $element);
-
-    /**
-     * Returns all the item's elements
-     *
-     * @return \ArrayIterator
-     */
-    public function getAllElements();
-
-    /**
-     * Returns the item's elements tag names
-     *
-     * @return array
-     */
-    public function listElements();
 }

--- a/src/FeedIo/Feed/NodeInterface.php
+++ b/src/FeedIo/Feed/NodeInterface.php
@@ -118,13 +118,6 @@ interface NodeInterface
     public function newCategory();
 
     /**
-     * returns a new ElementInterface
-     *
-     * @return \FeedIo\Feed\Node\ElementInterface
-     */
-    public function newElement();
-
-    /**
      * returns an element's value
      *
      * @param  string $name element name
@@ -140,42 +133,4 @@ interface NodeInterface
      * @return $this
      */
     public function set($name, $value);
-
-    /**
-     * returns the ElementIterator to iterate over ElementInterface instances called $name
-     *
-     * @param  string                            $name element name
-     * @return \FeedIo\Feed\Node\ElementIterator
-     */
-    public function getElementIterator($name);
-
-    /**
-     * returns true if an ElementInterface instance called $name exists
-     *
-     * @param  string  $name element name
-     * @return boolean true if the element exists
-     */
-    public function hasElement($name);
-
-    /**
-     * adds $element to the object's attributes
-     *
-     * @param  ElementInterface $element
-     * @return $this
-     */
-    public function addElement(ElementInterface $element);
-
-    /**
-     * Returns all the item's elements
-     *
-     * @return \ArrayIterator
-     */
-    public function getAllElements();
-
-    /**
-     * Returns the item's elements tag names
-     *
-     * @return array
-     */
-    public function listElements();
 }


### PR DESCRIPTION
Node and Element use ElementsAwareTrait, which implements methods that handles an Iterator of Element's. I Added a ElementsAwareInterface that's implemented by Node and Element. This allows the dev to use it for type hinting or regular instanceof checks in various situations.

It also fixes a conflict with the getValue($name) method added to the Element class by the ElementsAwareTrait and the getValue that was already a method of the Element class.