### PR TITLE
Fix feedio factory configuration

### DIFF
--- a/src/FeedIo/Factory/Builder/GuzzleClientBuilder.php
+++ b/src/FeedIo/Factory/Builder/GuzzleClientBuilder.php
@@ -19,6 +19,18 @@ use \GuzzleHttp\Client as GuzzleClient;
  */
 class GuzzleClientBuilder implements ClientBuilderInterface
 {
+    /**
+     * @var array
+     */
+    private $config = [];
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->config = $config;
+    }
 
     /**
      * This method MUST return a \FeedIo\Adapter\ClientInterface instance
@@ -26,7 +38,7 @@ class GuzzleClientBuilder implements ClientBuilderInterface
      */
     public function getClient()
     {
-        return new Client(new GuzzleClient);
+        return new Client(new GuzzleClient($this->config));
     }
  
     /**

--- a/src/FeedIo/Factory/Builder/NullLoggerBuilder.php
+++ b/src/FeedIo/Factory/Builder/NullLoggerBuilder.php
@@ -20,6 +20,15 @@ class NullLoggerBuilder implements LoggerBuilderInterface
 {
 
     /**
+     * @param array $config
+     */
+    public function __construct(array $config = [])
+    {
+        // Ignore config as NullLogger does not accept any config
+        // Done for FeedIo\Factory compatibility
+    }
+
+    /**
      * This method MUST return a valid PSR3 logger
      * @return \Psr\Log\NullLogger
      */

--- a/tests/FeedIo/Factory/Builder/MonologBuilderTest.php
+++ b/tests/FeedIo/Factory/Builder/MonologBuilderTest.php
@@ -33,7 +33,7 @@ class MonologBuilderTest extends \PHPUnit_Framework_TestCase
     public function testNewInvalidHandler()
     {
         $builder = new MonologBuilder();
-        $handler = $builder->newHandler('stdClass', []);
+        $builder->newHandler('stdClass', []);
     }
     
     public function testGetLogger()

--- a/tests/FeedIo/FactoryTest.php
+++ b/tests/FeedIo/FactoryTest.php
@@ -13,7 +13,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException FeedIo\Factory\MissingDependencyException
+     * @expectedException \FeedIo\Factory\MissingDependencyException
      */
     public function testCheckMissingDependency()
     {   
@@ -68,13 +68,15 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $factory = new Factory();
         $this->assertInstanceOf('\FeedIo\Factory\Builder\\MonologBuilder', $factory->getBuilder('monolog'));
+        $this->assertInstanceOf('\FeedIo\Factory\Builder\\GuzzleClientBuilder', $factory->getBuilder('guzzleclient'));
     }
     
     public function testGetExternalBuilder()
     {
         $factory = new Factory();
-        $this->assertInstanceOf('stdClass', $factory->getBuilder('stdClass'));       
+        $this->assertInstanceOf('\FeedIo\ExternalBuilder', $factory->getBuilder('\FeedIo\ExternalBuilder'));
     }
+
     public function testCreateWithMonolog()
     {
         $factory = Factory::create(['builder' => 'monolog']);
@@ -84,6 +86,27 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testGetFeedIoAfterCreate()
     {
         $factory = Factory::create();
+        $feedIo = $factory->getFeedIo();
+        $this->assertInstanceOf('\FeedIo\FeedIo', $feedIo);
+    }
+
+    public function testGetFeedIoAfterCreateWithCustomConfig()
+    {
+        $factory = Factory::create(
+            [
+                'builder' => 'Monolog',
+                'config' => [
+                    'foo' => true,
+                ],
+            ],
+            [
+                'builder' => 'GuzzleClient',
+                'config' => [
+                    'foo' => false,
+                ],
+            ]
+        );
+
         $feedIo = $factory->getFeedIo();
         $this->assertInstanceOf('\FeedIo\FeedIo', $feedIo);
     }
@@ -120,4 +143,10 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         return $builder;
     }
     
+}
+
+class ExternalBuilder {
+    public function __construct(array $config)
+    {
+    }
 }


### PR DESCRIPTION
Resolves #105 

There are couple of assumptions made or inherited by previous design (which I need to preserve for BC purposes):
- all builders (internal or external) need to have a constructor public with only one required argument - array (config). I'm aware of `newInstanceArgs` vs `newInstance` but checking all cases (is constructor public? does it expect array as a first param? is there only one required param? is that required param on first place?) just to instantiate the builder would be a major overkill. It's rational to expect the user to match builder definition.
- objects references passed inside a config are still preserved. This is important if you pass `handlers` config to Monolog but expect to have their reference outside.

As there is no official codestyle, I tried to follow what I came across in source.