### PR TITLE
Fixed error when lastModified is null

### DIFF
--- a/src/FeedIo/Command/ReadCommand.php
+++ b/src/FeedIo/Command/ReadCommand.php
@@ -44,7 +44,8 @@ class ReadCommand extends Command
 
         /** @var \FeedIo\Feed\ItemInterface $item */
         foreach ($feed as $i => $item) {
-            $output->writeln("<info>{$item->getLastModified()->format(\DateTime::ATOM)} : {$item->getTitle()}</info>");
+            $lastModified = $item->getLastModified() ?: new \DateTime();
+            $output->writeln("<info>{$lastModified->format(\DateTime::ATOM)} : {$item->getTitle()}</info>");
             $output->writeln("{$item->getDescription()}");
 
             $this->handleMedias($item, $output);


### PR DESCRIPTION
If $item->getLastModified() === null then $item->getLastModified()->format() throw a fatal error