### PR TITLE
createFromFormat() expects fromat to be a string

### DIFF
--- a/src/FeedIo/Adapter/Guzzle/Response.php
+++ b/src/FeedIo/Adapter/Guzzle/Response.php
@@ -55,7 +55,7 @@ class Response implements ResponseInterface
     public function getLastModified()
     {
         if ($this->psrResponse->hasHeader(static::HTTP_LAST_MODIFIED)) {
-            $lastModified = \DateTime::createFromFormat(\DateTime::RFC2822, $this->getHeader(static::HTTP_LAST_MODIFIED));
+            $lastModified = \DateTime::createFromFormat(\DateTime::RFC2822, $this->getHeader(static::HTTP_LAST_MODIFIED)[0]);
 
             return false === $lastModified ? null : $lastModified;
         }


### PR DESCRIPTION
This fixes:
```
DateTime::createFromFormat() expects parameter 2 to be string, array given
```
The 4.0 branch already includes this change.