### PR TITLE
backport #189 to 3.x; 'content:encode' as alias of 'description'

### DIFF
--- a/src/FeedIo/Standard/Rss.php
+++ b/src/FeedIo/Standard/Rss.php
@@ -113,7 +113,7 @@ class Rss extends XmlAbstract
         $ruleSet = parent::buildBaseRuleSet();
         $ruleSet
             ->add(new Link())
-            ->add(new Description())
+            ->add(new Description(), ['content:encoded'])
             ->add($this->getModifiedSinceRule(static::DATE_NODE_TAGNAME, ['lastBuildDate', 'lastPubDate']))
             ->add(new Category());
 


### PR DESCRIPTION
This fixes #211 

It is a backport of #189 to the 3.0 branch.