### PR TITLE
Correct small typo in docblock

### DIFF
--- a/src/FeedIo/Reader/Result.php
+++ b/src/FeedIo/Reader/Result.php
@@ -20,7 +20,7 @@ use FeedIo\FeedInterface;
  *
  * - the Feed instance
  * - Date and time of the request
- * - value of the 'modifiedSince' header sent throught the request
+ * - value of the 'modifiedSince' header sent through the request
  * - the raw response
  * - the DOM document
  * - URL of the feed


### PR DESCRIPTION
`throught` ➡`through`