### PR TITLE
Fix for TypeError

### DIFF
--- a/src/FeedIo/Standard/Rdf.php
+++ b/src/FeedIo/Standard/Rdf.php
@@ -40,6 +40,7 @@ class Rdf extends Rss
      */
     public function canHandle(Document $document) : bool
     {
+        if(!isset($document->getDOMDocument()->documentElement->tagName)) return false;
         return false !== strpos($document->getDOMDocument()->documentElement->tagName, static::ROOT_NODE_TAGNAME);
     }
 


### PR DESCRIPTION
`$document->getDOMDocument()->documentElement->tagName` can be null

Fix taken from https://github.com/nextcloud/news/issues/537#issuecomment-535395977