### PR TITLE
Added support for multiple custom fields with the same name

### DIFF
--- a/src/FeedIo/Formatter/XmlFormatter.php
+++ b/src/FeedIo/Formatter/XmlFormatter.php
@@ -95,7 +95,7 @@ class XmlFormatter implements FormatterInterface
         $rules = $ruleSet->getRules();
         $optionalFields = $node->listElements();
         foreach ($optionalFields as $optionalField) {
-            $rules[] = new OptionalField($optionalField);
+            $rules[$optionalField] = new OptionalField($optionalField);
         }
 
         return $rules;

--- a/src/FeedIo/Rule/OptionalField.php
+++ b/src/FeedIo/Rule/OptionalField.php
@@ -131,13 +131,23 @@ class OptionalField extends RuleAbstract
      */
     protected function addElement(\DomDocument $document, \DOMElement $rootElement, NodeInterface $node) : void
     {
-        $domElement = $document->createElement($this->getNodeName());
+        $addedElementsCount = 0;
+
         if ($node instanceof ElementsAwareInterface) {
             foreach ($node->getElementIterator($this->getNodeName()) as $element) {
+                $domElement = $document->createElement($this->getNodeName());
+
                 $this->buildDomElement($domElement, $element);
+
+                $rootElement->appendChild($domElement);
+
+                $addedElementsCount++;
             }
         }
 
-        $rootElement->appendChild($domElement);
+        if (! $addedElementsCount) {
+            // add an implicit empty element if the node had no elements matching this rule
+            $rootElement->appendChild($document->createElement($this->getNodeName()));
+        }
     }
 }

--- a/tests/FeedIo/FormatterTest.php
+++ b/tests/FeedIo/FormatterTest.php
@@ -67,11 +67,13 @@ class FormatterTest extends TestCase
         $item = new Item();
         $item->set('title', 'the title');
         $item->set('description', 'the description');
+        $item->set('custom', 'a custom value');
+        $item->set('custom', 'another custom value');
 
         $rules = $this->object->getAllRules(new RuleSet(), $item);
-        $this->assertCount(2, $rules);
+        $this->assertCount(3, $rules);
 
-        $ruleNames = array('title', 'description');
+        $ruleNames = array('title', 'description', 'custom');
         foreach ($rules as $rule) {
             $this->assertEquals(current($ruleNames), $rule->getNodeName());
             next($ruleNames);

--- a/tests/FeedIo/Rule/OptionalFieldTest.php
+++ b/tests/FeedIo/Rule/OptionalFieldTest.php
@@ -37,9 +37,9 @@ class OptionalFieldTest extends TestCase
 
         $this->assertTrue($item->hasElement('test'));
         $this->assertEquals('a test value', $item->getValue('test'));
-        
+
         $itemElements = $item->getElementIterator('test');
-        
+
         $count = 0;
         /** @var Element $itemElement */
         foreach ($itemElements as $itemElement) {
@@ -170,6 +170,26 @@ class OptionalFieldTest extends TestCase
         $this->assertEquals('value', $domElement->nodeValue);
 
         $this->assertTrue($domElement->hasAttribute('foo'));
+    }
+
+    public function testCreateMultipleElements()
+    {
+        $item = new Item();
+        $item->set('default', 'first value');
+        $item->set('default', 'second value');
+
+        $document = new \DOMDocument();
+        $rootElement = $document->createElement('feed');
+
+        $this->object->apply($document, $rootElement, $item);
+
+        $this->assertEquals(2, $rootElement->childNodes->count());
+
+        $this->assertEquals('default', $rootElement->childNodes->item(0)->nodeName);
+        $this->assertEquals('first value', $rootElement->childNodes->item(0)->nodeValue);
+
+        $this->assertEquals('default', $rootElement->childNodes->item(1)->nodeName);
+        $this->assertEquals('second value', $rootElement->childNodes->item(1)->nodeValue);
     }
 
     public function testDontCreateElement()

--- a/tests/FeedIo/StandardFormatter/FormatterTestAbstract.php
+++ b/tests/FeedIo/StandardFormatter/FormatterTestAbstract.php
@@ -60,6 +60,9 @@ abstract class FormatterTestAbstract extends TestCase
         $item->setLink('http://localhost/item/1');
         $item->set('author', 'name@domain.tld');
         $item->addCategory($category);
+        $item->set('custom', 'a sample value');
+        $item->set('custom', 'another sample value');
+
         $feed->add($item);
 
         $formatter = new XmlFormatter($this->standard);

--- a/tests/samples/expected-atom.xml
+++ b/tests/samples/expected-atom.xml
@@ -14,7 +14,9 @@
         <link href="http://localhost/item/1"/>
         <id>http://localhost/item/1</id>
         <updated>2014-12-01T00:00:00+00:00</updated>
-        <content>A great description</content>
         <author>name@domain.tld</author>
+        <content>A great description</content>
+        <custom>a sample value</custom>
+        <custom>another sample value</custom>
     </entry>
 </feed>

--- a/tests/samples/rss/expected-rss.xml
+++ b/tests/samples/rss/expected-rss.xml
@@ -14,8 +14,10 @@
             <description>A great description</description>
             <pubDate>Mon, 01 Dec 2014 00:00:00 +0000</pubDate>
             <category domain="http://localhost">sample</category>
-            <guid>http://localhost/item/1</guid>
             <author>name@domain.tld</author>
+            <guid>http://localhost/item/1</guid>
+            <custom>a sample value</custom>
+            <custom>another sample value</custom>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Hey, I'm trying to use feed-io to generate a Google products feed, where each entry can have multiple `g:shipping` fields. This leads to an unexpected behavior, simplified example:

```php
$item = $feed->newItem();

$item->set('g:shipping', 'Standard shipping');
$item->set('g:shipping', 'Two-day delivery');

$feed->add($item)
```

Which leads to the following Atom formatted output:

```xml
<entry>
    <g:shipping>Two-day delivery</g:shipping>
    <g:shipping>Two-day delivery</g:shipping>
</entry>
```

Instead of both values, we only get the last one - duplicated.

My attempt at fixing this comes in two parts:

- `OptionalField` rule now creates a DOM element for each of the elements on the node instance
- `XmlFormatter::getAllRules` now returns only a single `OptionalField` rule for each unique field to prevent duplicate elements

The PR also includes both tests for the previously unexpected behaviour and new tests for the new changes.

Some additional thoughts:

- the `OptionalField::addElement` code could be simplified if we don't care about adding empty element if the node has no values for the field (I preserved this behaviour since there is a test for it)
- the way I de-duplicate `OptionalField` rules in `XmlFormatter::getAllRules` causes a different order of the elements in the output, also not sure if we should be concerned about custom field names conflicting with other rules
- only tested with Atom output, no idea if any of this applies to the json output

