### PR TITLE
Basic Media-RSS support

### DIFF
--- a/src/FeedIo/Feed/Item/Media.php
+++ b/src/FeedIo/Feed/Item/Media.php
@@ -33,6 +33,22 @@ class Media implements MediaInterface
     protected $length;
 
     /**
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * @var string
+     */
+    protected $thumbnail;
+
+
+    /**
      * @return string
      */
     public function getNodeName() : string
@@ -115,4 +131,63 @@ class Media implements MediaInterface
 
         return $this;
     }
+
+
+    /**
+     * @return string
+     */
+    public function getTitle() : ? string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param  string $title
+     * @return MediaInterface
+     */
+    public function setTitle(?string $title) : MediaInterface
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription() : ? string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param  string $description
+     * @return MediaInterface
+     */
+    public function setDescription(?string $description) : MediaInterface
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getThumbnail() : ? string
+    {
+        return $this->thumbnail;
+    }
+
+    /**
+     * @param  string $thumbnail
+     * @return MediaInterface
+     */
+    public function setThumbnail(?string $thumbnail) : MediaInterface
+    {
+        $this->thumbnail = $thumbnail;
+
+        return $this;
+    }
+
 }

--- a/src/FeedIo/Feed/Item/Media.php
+++ b/src/FeedIo/Feed/Item/Media.php
@@ -189,5 +189,4 @@ class Media implements MediaInterface
 
         return $this;
     }
-
 }

--- a/src/FeedIo/Feed/Item/MediaInterface.php
+++ b/src/FeedIo/Feed/Item/MediaInterface.php
@@ -76,4 +76,37 @@ interface MediaInterface
      * @return MediaInterface
      */
     public function setLength(?string $length) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getTitle() : ? string;
+
+    /**
+     * @param  string $title
+     * @return MediaInterface
+     */
+    public function setTitle(?string $title) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getDescription() : ? string;
+
+    /**
+     * @param  string $description
+     * @return MediaInterface
+     */
+    public function setDescription(?string $description) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getThumbnail() : ? string;
+
+    /**
+     * @param  string $thumbnail
+     * @return MediaInterface
+     */
+    public function setThumbnail(?string $thumbnail) : MediaInterface;
 }

--- a/src/FeedIo/Rule/Media.php
+++ b/src/FeedIo/Rule/Media.php
@@ -53,20 +53,14 @@ class Media extends RuleAbstract
             if ($element->nodeName == "media:group" or $element->nodeName == "media:content") {
                 $media->setTitle($this->getChildValue($element, 'title', static::MRSS_NAMESPACE));
                 $media->setDescription($this->getChildValue($element, 'description', static::MRSS_NAMESPACE));
-                $thumbnails = $element->getElementsByTagNameNS(static::MRSS_NAMESPACE, "thumbnail");
-                if ($thumbnails->length > 0) {
-                    $media->setThumbnail($this->getAttributeValue($thumbnails->item(0), "url"));
-                }
+                $media->setThumbnail($this->getChildAttributeValue($element, 'thumbnail', 'url', static::MRSS_NAMESPACE));
 
                 if ($element->nodeName == "media:content") {
                     $media->setUrl($this->getAttributeValue($element, "url"));
                 }
 
                 if ($element->nodeName == "media:group") {
-                    $contents = $element->getElementsByTagNameNS(static::MRSS_NAMESPACE, "content");
-                    if ($contents->length > 0) {
-                        $media->setUrl($this->getAttributeValue($contents->item(0), "url"));
-                    }
+                    $media->setUrl($this->getChildAttributeValue($element, 'content', 'url', static::MRSS_NAMESPACE));
                 }
             } else {
                 $media

--- a/src/FeedIo/Rule/Media.php
+++ b/src/FeedIo/Rule/Media.php
@@ -50,23 +50,21 @@ class Media extends RuleAbstract
             $media = $node->newMedia();
             $media->setNodeName($element->nodeName);
 
-            if ($element->nodeName == "media:group" or $element->nodeName == "media:content") {
-                $media->setTitle($this->getChildValue($element, 'title', static::MRSS_NAMESPACE));
-                $media->setDescription($this->getChildValue($element, 'description', static::MRSS_NAMESPACE));
-                $media->setThumbnail($this->getChildAttributeValue($element, 'thumbnail', 'url', static::MRSS_NAMESPACE));
-
-                if ($element->nodeName == "media:content") {
-                    $media->setUrl($this->getAttributeValue($element, "url"));
-                }
-
-                if ($element->nodeName == "media:group") {
+            switch ($element->nodeName) {
+                case 'media:group':
+                    $this->initMedia($media, $element);
                     $media->setUrl($this->getChildAttributeValue($element, 'content', 'url', static::MRSS_NAMESPACE));
-                }
-            } else {
-                $media
-                    ->setType($this->getAttributeValue($element, 'type'))
-                    ->setUrl($this->getAttributeValue($element, $this->getUrlAttributeName()))
-                    ->setLength($this->getAttributeValue($element, 'length'));
+                    break;
+                case 'media:content':
+                    $this->initMedia($media, $element);
+                    $media->setUrl($this->getAttributeValue($element, "url"));
+                    break;
+                default:
+                    $media
+                        ->setType($this->getAttributeValue($element, 'type'))
+                        ->setUrl($this->getAttributeValue($element, $this->getUrlAttributeName()))
+                        ->setLength($this->getAttributeValue($element, 'length'));
+                    break;
             }
             $node->addMedia($media);
         }
@@ -85,6 +83,17 @@ class Media extends RuleAbstract
         $element->setAttribute('length', $media->getLength() ?? '');
 
         return $element;
+    }
+
+    /**
+     * @param \MediaInterface $media
+     * @param \DomElement $element
+     */
+    protected function initMedia(MediaInterface $media, \DOMElement $element): void
+    {
+        $media->setTitle($this->getChildValue($element, 'title', static::MRSS_NAMESPACE));
+        $media->setDescription($this->getChildValue($element, 'description', static::MRSS_NAMESPACE));
+        $media->setThumbnail($this->getChildAttributeValue($element, 'thumbnail', 'url', static::MRSS_NAMESPACE));
     }
 
     /**

--- a/src/FeedIo/Rule/Media.php
+++ b/src/FeedIo/Rule/Media.php
@@ -50,8 +50,7 @@ class Media extends RuleAbstract
             $media = $node->newMedia();
             $media->setNodeName($element->nodeName);
 
-            if ($element->nodeName == "media:group" or $element->nodeName == "media:content")
-            {
+            if ($element->nodeName == "media:group" or $element->nodeName == "media:content") {
                 $media->setTitle($this->getChildValue($element, 'title', static::MRSS_NAMESPACE));
                 $media->setDescription($this->getChildValue($element, 'description', static::MRSS_NAMESPACE));
                 $thumbnails = $element->getElementsByTagNameNS(static::MRSS_NAMESPACE, "thumbnail");
@@ -69,14 +68,11 @@ class Media extends RuleAbstract
                         $media->setUrl($this->getAttributeValue($contents->item(0), "url"));
                     }
                 }
-            }
-            else
-            {
+            } else {
                 $media
                     ->setType($this->getAttributeValue($element, 'type'))
                     ->setUrl($this->getAttributeValue($element, $this->getUrlAttributeName()))
                     ->setLength($this->getAttributeValue($element, 'length'));
-
             }
             $node->addMedia($media);
         }

--- a/src/FeedIo/RuleAbstract.php
+++ b/src/FeedIo/RuleAbstract.php
@@ -54,11 +54,12 @@ abstract class RuleAbstract
     /**
      * @param  \DOMElement $element
      * @param  string      $name
+     * @param  string      $ns
      * @return string|null
      */
-    public function getChildValue(\DOMElement $element, string $name) : ? string
+    public function getChildValue(\DOMElement $element, string $name, string $ns = "") : ? string
     {
-        $list = $element->getElementsByTagName($name);
+        $list = $element->getElementsByTagNameNS($ns, $name);
         if ($list->length > 0) {
             return $list->item(0)->nodeValue;
         }

--- a/src/FeedIo/RuleAbstract.php
+++ b/src/FeedIo/RuleAbstract.php
@@ -68,6 +68,24 @@ abstract class RuleAbstract
     }
 
     /**
+     * @param  \DOMElement $element
+     * @param  string      $child_name
+     * @param  string      $attribute_name
+     * @param  string      $ns
+     * @return string|null
+     */
+    public function getChildAttributeValue(\DOMElement $element, string $child_name, string $attribute_name, string $ns = "") : ? string
+    {
+        $list = $element->getElementsByTagNameNS($ns, $child_name);
+        if ($list->length > 0) {
+            return $list->item(0)->getAttribute($attribute_name);
+        }
+
+        return null;
+    }
+
+
+    /**
      * adds the accurate DomElement content according to the node's property
      *
      * @param \DomDocument $document

--- a/src/FeedIo/Standard/Atom.php
+++ b/src/FeedIo/Standard/Atom.php
@@ -17,6 +17,7 @@ use FeedIo\Rule\Atom\LinkNode;
 use FeedIo\Rule\Atom\Logo;
 use FeedIo\Rule\Description;
 use FeedIo\Rule\Language;
+use FeedIo\Rule\Media;
 use FeedIo\Rule\PublicId;
 use FeedIo\Rule\Atom\Category;
 use FeedIo\RuleSet;
@@ -94,7 +95,10 @@ class Atom extends XmlAbstract
         $ruleSet = $this->buildFeedRuleSet();
         $ruleSet
             ->add(new Author())
-            ->add(new Description('content'), ['summary']);
+            ->add(new Description('content'), ['summary'])
+            ->add(new Media(), ['media:group'])
+            ->add(new Media(), ['media:content'])
+        ;
 
         return $ruleSet;
     }

--- a/src/FeedIo/Standard/Rss.php
+++ b/src/FeedIo/Standard/Rss.php
@@ -107,6 +107,8 @@ class Rss extends XmlAbstract
             ->add(new Author(), ['dc:creator'])
             ->add(new PublicId())
             ->add(new Media(), ['media:thumbnail'])
+            ->add(new Media(), ['media:group'])
+            ->add(new Media(), ['media:content'])
             ;
 
         return $ruleSet;

--- a/tests/FeedIo/JsonFormatterTest.php
+++ b/tests/FeedIo/JsonFormatterTest.php
@@ -18,7 +18,6 @@ use \PHPUnit\Framework\TestCase;
 
 class JsonFormatterTest extends TestCase
 {
-
     const LOGO = 'http://localhost/logo.jpeg';
 
     public function testToString()

--- a/tests/FeedIo/Parser/MediaRSSTest.php
+++ b/tests/FeedIo/Parser/MediaRSSTest.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Parser;
+
+use FeedIo\Feed;
+use FeedIo\Parser\XmlParser as Parser;
+use FeedIo\Reader\Document;
+use FeedIo\Rule\DateTimeBuilder;
+use FeedIo\Standard\Atom;
+use Psr\Log\NullLogger;
+
+use \PHPUnit\Framework\TestCase;
+
+class MediaRssTest extends TestCase
+{
+    const SAMPLE_FILE = 'rss/sample-youtube.xml';
+
+    /**
+     * @return \FeedIo\StandardAbstract
+     */
+    public function getStandard()
+    {
+        return new Atom(new DateTimeBuilder());
+    }
+
+    public function setUp()
+    {
+        $standard = $this->getStandard();
+        $this->object = new Parser($standard, new NullLogger());
+    }
+
+    /**
+     * @param $filename
+     * @return Document
+     */
+    protected function buildDomDocument($filename)
+    {
+        $file = dirname(__FILE__)."/../../samples/{$filename}";
+        $domDocument = new \DOMDocument();
+        $domDocument->load($file, LIBXML_NOBLANKS | LIBXML_COMPACT);
+
+        return new Document($domDocument->saveXML());
+    }
+
+    public function testYoutubeFeed()
+    {
+        $document = $this->buildDomDocument(static::SAMPLE_FILE);
+        $feed = $this->object->parse($document, new Feed());
+
+        $this->assertEquals(1, count($feed));
+        foreach ($feed as $item) {
+            $this->assertTrue($item->hasMedia());
+            $media = $item->getMedias()->current();
+
+            $this->assertInstanceOf('\FeedIo\Feed\Item\MediaInterface', $media);
+            $this->assertEquals('YT_VIDEO_TITLE', $media->getTitle());
+            $this->assertEquals('https://i2.ytimg.com/vi/YT_VIDEO_ID/hqdefault.jpg', $media->getThumbnail());
+            $this->assertEquals("This is a\nmultiline\ndescription", $media->getDescription());
+            $this->assertEquals('https://www.youtube.com/v/YT_VIDEO_ID?version=3', $media->getUrl());
+        }
+    }
+}

--- a/tests/samples/rss/sample-youtube.xml
+++ b/tests/samples/rss/sample-youtube.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/" xmlns="http://www.w3.org/2005/Atom">
+    <link rel="self" href="http://www.youtube.com/feeds/videos.xml?channel_id=YT_CHANNEL_ID"/>
+    <id>yt:channel:YT_CHANNEL_ID</id>
+    <yt:channelId>YT_CHANNEL_ID</yt:channelId>
+    <title>YT_CHANNEL_TITLE</title>
+    <link rel="alternate" href="https://www.youtube.com/channel/YT_CHANNEL_ID"/>
+    <author>
+        <name>PBS Space Time</name>
+        <uri>https://www.youtube.com/channel/YT_CHANNEL_ID</uri>
+    </author>
+    <published>2015-02-09T16:24:44+00:00</published>
+    <entry>
+        <id>yt:video:YT_VIDEO_ID</id>
+        <yt:videoId>YT_VIDEO_ID</yt:videoId>
+        <yt:channelId>YT_CHANNEL_ID</yt:channelId>
+        <title>YT_VIDEO_TITLE</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=YT_VIDEO_ID"/>
+        <author>
+            <name>YT_VIDEO_AUTHOR</name>
+            <uri>https://www.youtube.com/channel/YT_CHANNEL_ID</uri>
+        </author>
+        <published>2019-11-11T19:45:00+00:00</published>
+        <updated>2019-11-22T15:26:42+00:00</updated>
+        <media:group>
+            <media:title>YT_VIDEO_TITLE</media:title>
+            <media:content url="https://www.youtube.com/v/YT_VIDEO_ID?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+            <media:thumbnail url="https://i2.ytimg.com/vi/YT_VIDEO_ID/hqdefault.jpg" width="480" height="360"/>
+            <media:description>This is a
+multiline
+description</media:description>
+            <media:community>
+                <media:starRating count="17083" average="4.91" min="1" max="5"/>
+                <media:statistics views="463700"/>
+            </media:community>
+        </media:group>
+    </entry>
+</feed>


### PR DESCRIPTION
This is my attempt to solve #240 

It has been a long time since I hacked with PHP so I am not familiar anymore with the nice way to do things. Do not hesitate to tell me if I made dirty things :)

The [Media-RSS](http://www.rssboard.org/media-rss) specification describe a lot of tags, but I just implemented those that are used (and useful) in youtube feeds: title, description, and thumbnail. Youtube provides other interesting metada (number of views etc.) which I might tackle in the future, but for now lets keep it simple :)

Media-RSS `<media:thumbnail>` tags were already supported by feed-io, but I am not comfortable with how it is handled. It looks like feed-io treats `<media:thumbnail>` tags as if it were actually the media, while the specification states that it represents a thumbnail for the actual media.
For instance, the media could be a large picture, or a video, and the `<media:thumbnail>` tag should be a thumbnail of that picture or video, but it is not the actual media.
I am not comfortable neither with the MediaInterface isThumbnail method. A media should **have** a thumbnail or not, but not **be** a thumbnail.
https://github.com/alexdebril/feed-io/blob/1b2f22653a9219a1ad261ca66749ab499dc42010/src/FeedIo/Feed/Item/MediaInterface.php#L45

What do you think?

Éloi