### PR TITLE
Full MediaRSS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - HTTP Headers support when reading feeds in order to save network traffic
 - Detection of the format (RSS / Atom) when reading feeds
 - Enclosure support to handle external medias like audio content
+- Media-RSS support
 - Feed logo support (RSS + Atom)
 - PSR compliant logging
 - Content filtering to fetch only the newest items

--- a/src/FeedIo/Feed/Item/Media.php
+++ b/src/FeedIo/Feed/Item/Media.php
@@ -12,6 +12,42 @@ namespace FeedIo\Feed\Item;
 
 use FeedIo\Feed\ArrayableInterface;
 
+abstract class MediaConstant
+{
+    /**
+     * @param string|null $value
+     */
+    public static function fromXML(?string $value) : ?int
+    {
+        return static::VALUES[$value ? strtolower($value) : $value] ?? null;
+    }
+}
+
+abstract class MediaDescriptionType extends MediaConstant
+{
+    const Plain = 1;
+    const HTML = 2;
+
+    const VALUES = array(
+        null => MediaDescriptionType::Plain,
+        "plain" => MediaDescriptionType::Plain,
+        "html" => MediaDescriptionType::HTML,
+    );
+}
+
+abstract class MediaTitleType extends MediaConstant
+{
+    const Plain = 1;
+    const HTML = 2;
+
+    const VALUES = array(
+        null => MediaTitleType::Plain,
+        "plain" => MediaTitleType::Plain,
+        "html" => MediaTitleType::HTML,
+    );
+}
+
+
 class Media implements MediaInterface, ArrayableInterface
 {
     /**
@@ -45,10 +81,129 @@ class Media implements MediaInterface, ArrayableInterface
     protected $description;
 
     /**
-     * @var string
+     * @var int
+     */
+    protected $rights;
+
+    /**
+     * @var int
+     */
+    protected $titleType;
+
+    /**
+     * @var int
+     */
+    protected $descriptionType;
+
+    /**
+     * @var array
+     */
+    protected $keywords = array();
+
+    /**
+     * @var array
+     */
+    protected $comments = array();
+
+    /**
+     * @var array
+     */
+    protected $responses = array();
+
+    /**
+     * @var array
+     */
+    protected $backlinks = array();
+
+    /**
+     * @var array
+     */
+    protected $credits = array();
+
+    /**
+     * @var array
+     */
+    protected $texts = array();
+
+    /**
+     * @var array
+     */
+    protected $prices = array();
+
+    /**
+     * @var array
+     */
+    protected $subTitles = array();
+
+    /**
+     * @var array
+     */
+    protected $scenes = array();
+
+    /**
+     * @var MediaContentInterface
+     */
+    protected $content;
+
+    /**
+     * @var MediaThumbnailInterface
      */
     protected $thumbnail;
 
+    /**
+     * @var MediaCategoryInterface
+     */
+    protected $category;
+
+    /**
+     * @var MediaHashInterface
+     */
+    protected $hash;
+
+    /**
+     * @var MediaEmbedInterface
+     */
+    protected $embed;
+
+    /**
+     * @var MediaLicenseInterface
+     */
+    protected $license;
+
+    /**
+     * @var MediaCommunityInterface
+     */
+    protected $community;
+
+    /**
+     * @var MediaRestrictionInterface
+     */
+    protected $restriction;
+
+    /**
+     * @var MediaRatingInterface
+     */
+    protected $rating;
+
+    /**
+     * @var MediaCopyrightInterface
+     */
+    protected $copyright;
+
+    /**
+     * @var MediaPlayerInterface
+     */
+    protected $player;
+
+    /**
+     * @var MediaStatusInterface
+     */
+    protected $status;
+
+    /**
+     * @var MediaPeerLinkInterface
+     */
+    protected $peerLink;
 
     /**
      * @return string
@@ -126,7 +281,6 @@ class Media implements MediaInterface, ArrayableInterface
         return $this;
     }
 
-
     /**
      * @return string
      */
@@ -168,16 +322,264 @@ class Media implements MediaInterface, ArrayableInterface
     /**
      * @return string
      */
-    public function getThumbnail() : ? string
+    public function getRights() : ?int
+    {
+        return $this->rights;
+    }
+
+    /**
+     * @param  int $rights
+     * @return MediaInterface
+     */
+    public function setRights(int $rights) : MediaInterface
+    {
+        $this->rights = $rights;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTitleType() : ?int
+    {
+        return $this->titleType;
+    }
+
+    /**
+     * @param  int $titleType
+     * @return MediaInterface
+     */
+    public function setTitleType(?int $titleType) : MediaInterface
+    {
+        $this->titleType = $titleType;
+
+        return $this;
+    }
+
+
+    /**
+     * @return int
+     */
+    public function getDescriptionType() : ?int
+    {
+        return $this->descriptionType;
+    }
+
+    /**
+     * @param  int $descriptionType
+     * @return MediaInterface
+     */
+    public function setDescriptionType(?int $descriptionType) : MediaInterface
+    {
+        $this->descriptionType = $descriptionType;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getKeywords() : array
+    {
+        return $this->keywords;
+    }
+
+    /**
+     * @param  array $keywords
+     * @return MediaInterface
+     */
+    public function setKeywords(array $keywords) : MediaInterface
+    {
+        $this->keywords = $keywords;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getComments() : array
+    {
+        return $this->comments;
+    }
+
+    /**
+     * @param  array $comments
+     * @return MediaInterface
+     */
+    public function setComments(array $comments) : MediaInterface
+    {
+        $this->comments = $comments;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getResponses() : array
+    {
+        return $this->responses;
+    }
+
+    /**
+     * @param  array $responses
+     * @return MediaInterface
+     */
+    public function setResponses(array $responses) : MediaInterface
+    {
+        $this->responses = $responses;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getBacklinks() : array
+    {
+        return $this->backlinks;
+    }
+
+    /**
+     * @param  array $backlinks
+     * @return MediaInterface
+     */
+    public function setBacklinks(array $backlinks) : MediaInterface
+    {
+        $this->backlinks = $backlinks;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCredits() : array
+    {
+        return $this->credits;
+    }
+
+    /**
+     * @param  array $credits
+     * @return MediaInterface
+     */
+    public function setCredits(array $credits) : MediaInterface
+    {
+        $this->credits = $credits;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTexts() : array
+    {
+        return $this->texts;
+    }
+
+    /**
+     * @param  array $texts
+     * @return MediaInterface
+     */
+    public function setTexts(array $texts) : MediaInterface
+    {
+        $this->texts = $texts;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPrices() : array
+    {
+        return $this->prices;
+    }
+
+    /**
+     * @param  array $prices
+     * @return MediaInterface
+     */
+    public function setPrices(array $prices) : MediaInterface
+    {
+        $this->prices = $prices;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSubTitles() : array
+    {
+        return $this->subTitles;
+    }
+
+    /**
+     * @param  array $subTitles
+     * @return MediaInterface
+     */
+    public function setSubTitles(array $subTitles) : MediaInterface
+    {
+        $this->subTitles = $subTitles;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getScenes() : array
+    {
+        return $this->scenes;
+    }
+
+    /**
+     * @param  array $scenes
+     * @return MediaInterface
+     */
+    public function setScenes(array $scenes) : MediaInterface
+    {
+        $this->scenes = $scenes;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaContentInterface
+     */
+    public function getContent() : MediaContentInterface
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param  MediaContentInterface $content
+     * @return MediaInterface
+     */
+    public function setContent(MediaContentInterface $content) : MediaInterface
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaThumbnailInterface
+     */
+    public function getThumbnail() : MediaThumbnailInterface
     {
         return $this->thumbnail;
     }
 
     /**
-     * @param  string $thumbnail
+     * @param  MediaThumbnailInterface $thumbnail
      * @return MediaInterface
      */
-    public function setThumbnail(?string $thumbnail) : MediaInterface
+    public function setThumbnail(MediaThumbnailInterface $thumbnail) : MediaInterface
     {
         $this->thumbnail = $thumbnail;
 
@@ -190,5 +592,214 @@ class Media implements MediaInterface, ArrayableInterface
     public function toArray() : array
     {
         return get_object_vars($this);
+    }
+
+    /**
+     * @return MediaCategoryInterface
+     */
+    public function getCategory() : MediaCategoryInterface
+    {
+        return $this->category;
+    }
+
+    /**
+     * @param  MediaCategoryInterface $category
+     * @return MediaInterface
+     */
+    public function setCategory(MediaCategoryInterface $category) : MediaInterface
+    {
+        $this->category = $category;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaPlayerInterface
+     */
+    public function getPlayer() : MediaPlayerInterface
+    {
+        return $this->player;
+    }
+
+    /**
+     * @param  MediaPlayerInterface $player
+     * @return MediaInterface
+     */
+    public function setPlayer(MediaPlayerInterface $player) : MediaInterface
+    {
+        $this->player = $player;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaHashInterface
+     */
+    public function getHash() : MediaHashInterface
+    {
+        return $this->hash;
+    }
+
+    /**
+     * @param  MediaHashInterface $hash
+     * @return MediaInterface
+     */
+    public function setHash(MediaHashInterface $hash) : MediaInterface
+    {
+        $this->hash = $hash;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaEmbedInterface
+     */
+    public function getEmbed() : MediaEmbedInterface
+    {
+        return $this->embed;
+    }
+
+    /**
+     * @param  MediaEmbedInterface $embed
+     * @return MediaInterface
+     */
+    public function setEmbed(MediaEmbedInterface $embed) : MediaInterface
+    {
+        $this->embed = $embed;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaLicenseInterface
+     */
+    public function getLicense() : MediaLicenseInterface
+    {
+        return $this->license;
+    }
+
+    /**
+     * @param  MediaLicenseInterface $license
+     * @return MediaInterface
+     */
+    public function setLicense(MediaLicenseInterface $license) : MediaInterface
+    {
+        $this->license = $license;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaCommunityInterface
+     */
+    public function getCommunity() : MediaCommunityInterface
+    {
+        return $this->community;
+    }
+
+    /**
+     * @param  MediaCommunityInterface $community
+     * @return MediaInterface
+     */
+    public function setCommunity(MediaCommunityInterface $community) : MediaInterface
+    {
+        $this->community = $community;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaRestrictionInterface
+     */
+    public function getRestriction() : MediaRestrictionInterface
+    {
+        return $this->restriction;
+    }
+
+    /**
+     * @param  MediaRestrictionInterface $restriction
+     * @return MediaInterface
+     */
+    public function setRestriction(MediaRestrictionInterface $restriction) : MediaInterface
+    {
+        $this->restriction = $restriction;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaRatingInterface
+     */
+    public function getRating() : MediaRatingInterface
+    {
+        return $this->rating;
+    }
+
+    /**
+     * @param  MediaRatingInterface $rating
+     * @return MediaInterface
+     */
+    public function setRating(MediaRatingInterface $rating) : MediaInterface
+    {
+        $this->rating = $rating;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaCopyrightInterface
+     */
+    public function getCopyright() : MediaCopyrightInterface
+    {
+        return $this->copyright;
+    }
+
+    /**
+     * @param  MediaCopyrightInterface $copyright
+     * @return MediaInterface
+     */
+    public function setCopyright(MediaCopyrightInterface $copyright) : MediaInterface
+    {
+        $this->copyright = $copyright;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaStatusInterface
+     */
+    public function getStatus() : MediaStatusInterface
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param  MediaStatusInterface $status
+     * @return MediaInterface
+     */
+    public function setStatus(MediaStatusInterface $status) : MediaInterface
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaPeerLinkInterface
+     */
+    public function getPeerLink() : MediaPeerLinkInterface
+    {
+        return $this->peerLink;
+    }
+
+    /**
+     * @param  MediaPeerLinkInterface $peerLink
+     * @return MediaInterface
+     */
+    public function setPeerLink(MediaPeerLinkInterface $peerLink) : MediaInterface
+    {
+        $this->peerLink = $peerLink;
+
+        return $this;
     }
 }

--- a/src/FeedIo/Feed/Item/Media.php
+++ b/src/FeedIo/Feed/Item/Media.php
@@ -70,16 +70,6 @@ class Media implements MediaInterface, ArrayableInterface
     }
 
     /**
-     * @deprecated
-     * @return bool
-     */
-    public function isThumbnail() : bool
-    {
-        trigger_error('Method isThumbnail is deprecated and will be removed in feed-io 5.0', E_USER_DEPRECATED);
-        return $this->nodeName === 'media:thumbnail';
-    }
-
-    /**
      * @return string
      */
     public function getType() : ? string

--- a/src/FeedIo/Feed/Item/MediaCategory.php
+++ b/src/FeedIo/Feed/Item/MediaCategory.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaCategory implements MediaCategoryInterface
+{
+    /**
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * @var string
+     */
+    protected $label;
+
+    /**
+     * @var string
+     */
+    protected $scheme;
+
+    /**
+     * @return string
+     */
+    public function getText() : ?string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param  string $text
+     * @return MediaCategoryInterface
+     */
+    public function setText(?string $text) : MediaCategoryInterface
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabel() : ?string
+    {
+        return $this->label;
+    }
+
+    /**
+     * @param  string $label
+     * @return MediaCategoryInterface
+     */
+    public function setLabel(?string $label) : MediaCategoryInterface
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getScheme() : ?string
+    {
+        return $this->scheme;
+    }
+
+    /**
+     * @param  string $scheme
+     * @return MediaCategoryInterface
+     */
+    public function setScheme(?string $scheme) : MediaCategoryInterface
+    {
+        $this->scheme = $scheme;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaCategoryInterface.php
+++ b/src/FeedIo/Feed/Item/MediaCategoryInterface.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaCategoryInterface
+{
+    /**
+     * @return string
+     */
+    public function getText() : ?string;
+
+    /**
+     * @param  string $category
+     * @return MediaCategoryInterface
+     */
+    public function setText(?string $category) : MediaCategoryInterface;
+
+
+    /**
+     * @return string
+     */
+    public function getLabel() : ?string;
+
+    /**
+     * @param  string $label
+     * @return MediaCategoryInterface
+     */
+    public function setLabel(?string $label) : MediaCategoryInterface;
+
+
+    /**
+     * @return string
+     */
+    public function getScheme() : ?string;
+
+    /**
+     * @param  string $scheme
+     * @return MediaCategoryInterface
+     */
+    public function setScheme(?string $scheme) : MediaCategoryInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaCommunity.php
+++ b/src/FeedIo/Feed/Item/MediaCommunity.php
@@ -1,0 +1,182 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaCommunity implements MediaCommunityInterface
+{
+    /**
+     * @var float
+     */
+    protected $starRatingAverage;
+
+    /**
+     * @var int
+     */
+    protected $starRatingCount;
+
+    /**
+     * @var int
+     */
+    protected $starRatingMin;
+
+    /**
+     * @var int
+     */
+    protected $starRatingMax;
+
+    /**
+     * @var int
+     */
+    protected $nbViews;
+
+    /**
+     * @var int
+     */
+    protected $nbFavorites;
+
+    /**
+     * @var array
+     */
+    protected $tags = array();
+
+    /**
+     * @return float
+     */
+    public function getStarRatingAverage() : ?float
+    {
+        return $this->starRatingAverage;
+    }
+
+    /**
+     * @param  float $starRatingAverage
+     * @return MediaCommunityInterface
+     */
+    public function setStarRatingAverage(?float $starRatingAverage) : MediaCommunityInterface
+    {
+        $this->starRatingAverage = $starRatingAverage;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStarRatingCount() : ?int
+    {
+        return $this->starRatingCount;
+    }
+
+    /**
+     * @param  int $starRatingCount
+     * @return MediaCommunityInterface
+     */
+    public function setStarRatingCount(?int $starRatingCount) : MediaCommunityInterface
+    {
+        $this->starRatingCount = $starRatingCount;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStarRatingMin() : ?int
+    {
+        return $this->starRatingMin;
+    }
+
+    /**
+     * @param  int $starRatingMin
+     * @return MediaCommunityInterface
+     */
+    public function setStarRatingMin(?int $starRatingMin) : MediaCommunityInterface
+    {
+        $this->starRatingMin = $starRatingMin;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStarRatingMax() : ?int
+    {
+        return $this->starRatingMax;
+    }
+
+    /**
+     * @param  int $starRatingMax
+     * @return MediaCommunityInterface
+     */
+    public function setStarRatingMax(?int $starRatingMax) : MediaCommunityInterface
+    {
+        $this->starRatingMax = $starRatingMax;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNbViews() : ?int
+    {
+        return $this->nbViews;
+    }
+
+    /**
+     * @param  int $nbViews
+     * @return MediaCommunityInterface
+     */
+    public function setNbViews(?int $nbViews) : MediaCommunityInterface
+    {
+        $this->nbViews = $nbViews;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNbFavorites() : ?int
+    {
+        return $this->nbFavorites;
+    }
+
+    /**
+     * @param  int $nbFavorites
+     * @return MediaCommunityInterface
+     */
+    public function setNbFavorites(?int $nbFavorites) : MediaCommunityInterface
+    {
+        $this->nbFavorites = $nbFavorites;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTags() : array
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param  array $tags
+     * @return MediaCommunityInterface
+     */
+    public function setTags(array $tags) : MediaCommunityInterface
+    {
+        $this->tags = $tags;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaCommunityInterface.php
+++ b/src/FeedIo/Feed/Item/MediaCommunityInterface.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaCommunityInterface
+{
+    /**
+     * @return float
+     */
+    public function getStarRatingAverage() : ?float;
+
+    /**
+     * @param  float $starRatingAverage
+     * @return MediaCommunityInterface
+     */
+    public function setStarRatingAverage(?float $starRatingAverage) : MediaCommunityInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getStarRatingCount() : ?int;
+
+    /**
+     * @param  string $starRatingCount
+     * @return MediaCommunityInterface
+     */
+    public function setStarRatingCount(?int $starRatingCount) : MediaCommunityInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getStarRatingMin() : ?int;
+
+    /**
+     * @param  string $starRatingMin
+     * @return MediaCommunityInterface
+     */
+    public function setStarRatingMin(?int $starRatingMin) : MediaCommunityInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getStarRatingMax() : ?int;
+
+    /**
+     * @param  string $starRatingMax
+     * @return MediaCommunityInterface
+     */
+    public function setStarRatingMax(?int $starRatingMax) : MediaCommunityInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getNbViews() : ?int;
+
+    /**
+     * @param  string $nbViews
+     * @return MediaCommunityInterface
+     */
+    public function setNbViews(?int $nbViews) : MediaCommunityInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getNbFavorites() : ?int;
+
+    /**
+     * @param  string $nbFavorites
+     * @return MediaCommunityInterface
+     */
+    public function setNbFavorites(?int $nbFavorites) : MediaCommunityInterface;
+
+
+    /**
+     * @return array
+     */
+    public function getTags() : array;
+
+    /**
+     * @param  string $tags
+     * @return MediaCommunityInterface
+     */
+    public function setTags(array $tags) : MediaCommunityInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaContent.php
+++ b/src/FeedIo/Feed/Item/MediaContent.php
@@ -1,0 +1,308 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+abstract class MediaContentMedium extends MediaConstant
+{
+    const Image = 1;
+    const Audio = 2;
+    const Video = 3;
+    const Document = 4;
+    const Executable = 5;
+
+    const VALUES = array(
+        "image" => MediaContentMedium::Image,
+        "audio" => MediaContentMedium::Audio,
+        "video" => MediaContentMedium::Video,
+        "document" => MediaContentMedium::Document,
+        "executable" => MediaContentMedium::Executable,
+    );
+}
+
+abstract class MediaContentExpression extends MediaConstant
+{
+    const Sample = 1;
+    const Full = 2;
+    const NonStop = 3;
+
+    const VALUES = array(
+        "sample" => MediaContentExpression::Sample,
+        "full" => MediaContentExpression::Full,
+        "nonstop" => MediaContentExpression::NonStop,
+    );
+}
+
+class MediaContent implements MediaContentInterface
+{
+    /**
+     * @var int
+     */
+    protected $fileSize;
+
+    /**
+     * @var int
+     */
+    protected $bitrate;
+
+    /**
+     * @var int
+     */
+    protected $framerate;
+
+    /**
+     * @var float
+     */
+    protected $samplingrate;
+
+    /**
+     * @var int
+     */
+    protected $duration;
+
+    /**
+     * @var int
+     */
+    protected $height;
+
+    /**
+     * @var int
+     */
+    protected $width;
+
+    /**
+     * @var string
+     */
+    protected $lang;
+
+    /**
+     * @var int
+     */
+    protected $expression;
+
+    /**
+     * @var int
+     */
+    protected $medium;
+
+    /**
+     * @var bool
+     */
+    protected $default = true;
+
+    /**
+     * @return int
+     */
+    public function getFileSize() : ?int
+    {
+        return $this->fileSize;
+    }
+
+    /**
+     * @param  int $fileSize
+     * @return MediaContentInterface
+     */
+    public function setFileSize(?int $fileSize) : MediaContentInterface
+    {
+        $this->fileSize = $fileSize;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getBitrate() : ?int
+    {
+        return $this->bitrate;
+    }
+
+    /**
+     * @param  int $bitrate
+     * @return MediaContentInterface
+     */
+    public function setBitrate(?int $bitrate) : MediaContentInterface
+    {
+        $this->bitrate = $bitrate;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFramerate() : ?int
+    {
+        return $this->framerate;
+    }
+
+    /**
+     * @param  int $framerate
+     * @return MediaContentInterface
+     */
+    public function setFramerate(?int $framerate) : MediaContentInterface
+    {
+        $this->framerate = $framerate;
+
+        return $this;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getSamplingrate() : ?float
+    {
+        return $this->samplingrate;
+    }
+
+    /**
+     * @param  float $samplingrate
+     * @return MediaContentInterface
+     */
+    public function setSamplingrate(?float $samplingrate) : MediaContentInterface
+    {
+        $this->samplingrate = $samplingrate;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDuration() : ?int
+    {
+        return $this->duration;
+    }
+
+    /**
+     * @param  int $duration
+     * @return MediaContentInterface
+     */
+    public function setDuration(?int $duration) : MediaContentInterface
+    {
+        $this->duration = $duration;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getHeight() : ?int
+    {
+        return $this->height;
+    }
+
+    /**
+     * @param  int $height
+     * @return MediaContentInterface
+     */
+    public function setHeight(?int $height) : MediaContentInterface
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getWidth() : ?int
+    {
+        return $this->width;
+    }
+
+    /**
+     * @param  int $width
+     * @return MediaContentInterface
+     */
+    public function setWidth(?int $width) : MediaContentInterface
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLang() : ?string
+    {
+        return $this->lang;
+    }
+
+    /**
+     * @param  string $lang
+     * @return MediaContentInterface
+     */
+    public function setLang(?string $lang) : MediaContentInterface
+    {
+        $this->lang = $lang;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getExpression() : ?int
+    {
+        return $this->expression;
+    }
+
+    /**
+     * @param  int $expression
+     * @return MediaContentInterface
+     */
+    public function setExpression(?int $expression) : MediaContentInterface
+    {
+        $this->expression = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMedium() : ?int
+    {
+        return $this->medium;
+    }
+
+    /**
+     * @param  int $medium
+     * @return MediaContentInterface
+     */
+    public function setMedium(?int $medium) : MediaContentInterface
+    {
+        $this->medium = $medium;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDefault() : bool
+    {
+        return $this->default;
+    }
+
+    /**
+     * @param bool $default
+     * @return MediaContentInterface
+     */
+    public function setDefault(bool $default) : MediaContentInterface
+    {
+        $this->default = $default;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaContentInterface.php
+++ b/src/FeedIo/Feed/Item/MediaContentInterface.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaContentInterface
+{
+
+    /**
+     * @return int
+     */
+    public function getFileSize() : ?int;
+
+    /**
+     * @param  string $fileSize
+     * @return MediaContentInterface
+     */
+    public function setFileSize(?int $fileSize) : MediaContentInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getBitrate() : ?int;
+
+    /**
+     * @param  string $bitrate
+     * @return MediaContentInterface
+     */
+    public function setBitrate(?int $bitrate) : MediaContentInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getFramerate() : ?int;
+
+    /**
+     * @param  string $framerate
+     * @return MediaContentInterface
+     */
+    public function setFramerate(?int $framerate) : MediaContentInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getSamplingrate() : ?float;
+
+    /**
+     * @param  string $samplingrate
+     * @return MediaContentInterface
+     */
+    public function setSamplingrate(?float $samplingrate) : MediaContentInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getDuration() : ?int;
+
+    /**
+     * @param  string $duration
+     * @return MediaContentInterface
+     */
+    public function setDuration(?int $duration) : MediaContentInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getHeight() : ?int;
+
+    /**
+     * @param  string $height
+     * @return MediaContentInterface
+     */
+    public function setHeight(?int $height) : MediaContentInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getWidth() : ?int;
+
+    /**
+     * @param  string $width
+     * @return MediaContentInterface
+     */
+    public function setWidth(?int $width) : MediaContentInterface;
+
+
+    /**
+     * @return string
+     */
+    public function getLang() : ?string;
+
+    /**
+     * @param  string $lang
+     * @return MediaContentInterface
+     */
+    public function setLang(?string $lang) : MediaContentInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getExpression() : ?int;
+
+    /**
+     * @param  string $expression
+     * @return MediaContentInterface
+     */
+    public function setExpression(?int $expression) : MediaContentInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getMedium() : ?int;
+
+    /**
+     * @param  string $medium
+     * @return MediaContentInterface
+     */
+    public function setMedium(?int $medium) : MediaContentInterface;
+
+    /**
+     * @return bool
+     */
+    public function isDefault() : bool;
+
+    /**
+     * @param bool $default
+     * @return MediaContentInterface
+     */
+    public function setDefault(bool $default) : MediaContentInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaCopyright.php
+++ b/src/FeedIo/Feed/Item/MediaCopyright.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaCopyright implements MediaCopyrightInterface
+{
+    /**
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @return string
+     */
+    public function getContent() : ?string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param  string $content
+     * @return MediaCopyrightInterface
+     */
+    public function setContent(?string $content) : MediaCopyrightInterface
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl() : ?string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param  string $url
+     * @return MediaCopyrightInterface
+     */
+    public function setUrl(?string $url) : MediaCopyrightInterface
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaCopyrightInterface.php
+++ b/src/FeedIo/Feed/Item/MediaCopyrightInterface.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaCopyrightInterface
+{
+    /**
+     * @return string
+     */
+    public function getContent() : ?string;
+
+    /**
+     * @param  string $copyright
+     * @return MediaCopyrightInterface
+     */
+    public function setContent(?string $copyright) : MediaCopyrightInterface;
+
+    /**
+     * @return string
+     */
+    public function getUrl() : ?string;
+
+    /**
+     * @param  string $url
+     * @return MediaCopyrightInterface
+     */
+    public function setUrl(?string $url) : MediaCopyrightInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaCredit.php
+++ b/src/FeedIo/Feed/Item/MediaCredit.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+abstract class MediaCreditScheme extends MediaConstant
+{
+    const URN_EBU = 1;
+    const URN_YVS = 2;
+
+    const VALUES = array(
+        null => MediaCreditScheme::URN_EBU,
+        "urn:ebu" => MediaCreditScheme::URN_EBU,
+        "urn:yvs" => MediaCreditScheme::URN_YVS,
+    );
+}
+
+class MediaCredit
+{
+    /**
+     * @var int
+     */
+    protected $scheme;
+
+    /**
+     * @var string
+     */
+    protected $role;
+
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * @param  int $scheme
+     * @return MediaCredit
+     */
+    public function setScheme(int $scheme) : MediaCredit
+    {
+        $this->scheme = $scheme;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getScheme() : ? int
+    {
+        return $this->scheme;
+    }
+
+    /**
+     * @param  string $role
+     * @return MediaCredit
+     */
+    public function setRole(?string $role) : MediaCredit
+    {
+        $this->role = $role;
+
+        return $this;
+    }
+
+    public function getRole() : ? string
+    {
+        return $this->role;
+    }
+
+    /**
+     * @param  string $value
+     * @return MediaCredit
+     */
+    public function setValue(string $value) : MediaCredit
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function getValue() : string
+    {
+        return $this->value;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaEmbed.php
+++ b/src/FeedIo/Feed/Item/MediaEmbed.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaEmbed implements MediaEmbedInterface
+{
+    /**
+     /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @var int
+     */
+    protected $width;
+
+    /**
+     * @var int
+     */
+    protected $height;
+
+    /**
+     * @var array
+     */
+    protected $params = array();
+
+    /**
+     * @return string
+     */
+    public function getUrl() : ?string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param  string $url
+     * @return MediaEmbedInterface
+     */
+    public function setUrl(?string $url) : MediaEmbedInterface
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getWidth() : ?int
+    {
+        return $this->width;
+    }
+
+    /**
+     * @param  int $width
+     * @return MediaEmbedInterface
+     */
+    public function setWidth(?int $width) : MediaEmbedInterface
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getHeight() : ?int
+    {
+        return $this->height;
+    }
+
+    /**
+     * @param  int $height
+     * @return MediaEmbedInterface
+     */
+    public function setHeight(?int $height) : MediaEmbedInterface
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParams() : array
+    {
+        return $this->params;
+    }
+
+    /**
+     * @param  array $params
+     * @return MediaEmbedInterface
+     */
+    public function setParams(array $params) : MediaEmbedInterface
+    {
+        $this->params = $params;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaEmbedInterface.php
+++ b/src/FeedIo/Feed/Item/MediaEmbedInterface.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaEmbedInterface
+{
+    /**
+     * @return string
+     */
+    public function getUrl() : ?string;
+
+    /**
+     * @param  string $url
+     * @return MediaEmbedInterface
+     */
+    public function setUrl(?string $url) : MediaEmbedInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getWidth() : ?int;
+
+    /**
+     * @param  string $width
+     * @return MediaEmbedInterface
+     */
+    public function setWidth(?int $width) : MediaEmbedInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getHeight() : ?int;
+
+    /**
+     * @param  string $height
+     * @return MediaEmbedInterface
+     */
+    public function setHeight(?int $height) : MediaEmbedInterface;
+
+
+    /**
+     * @return array
+     */
+    public function getParams() : array;
+
+    /**
+     * @param  string $params
+     * @return MediaEmbedInterface
+     */
+    public function setParams(array $params) : MediaEmbedInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaHash.php
+++ b/src/FeedIo/Feed/Item/MediaHash.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+abstract class MediaHashAlgo extends MediaConstant
+{
+    const MD5 = 1;
+    const SHA1 = 2;
+
+    const VALUES = array(
+        null => MediaHashAlgo::MD5,
+        "md5" => MediaHashAlgo::MD5,
+        "sha1" => MediaHashAlgo::SHA1,
+    );
+}
+
+
+class MediaHash implements MediaHashInterface
+{
+    /**
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * @var int
+     */
+    protected $algo;
+
+    /**
+     * @return string
+     */
+    public function getContent() : ?string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param  string $content
+     * @return MediaHashInterface
+     */
+    public function setContent(?string $content) : MediaHashInterface
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlgo() : ?int
+    {
+        return $this->algo;
+    }
+
+    /**
+     * @param  int $algo
+     * @return MediaHashInterface
+     */
+    public function setAlgo(?int $algo) : MediaHashInterface
+    {
+        $this->algo = $algo;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaHashInterface.php
+++ b/src/FeedIo/Feed/Item/MediaHashInterface.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaHashInterface
+{
+    /**
+     * @return string
+     */
+    public function getContent() : ?string;
+
+    /**
+     * @param  string $content
+     * @return MediaHashInterface
+     */
+    public function setContent(?string $content) : MediaHashInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getAlgo() : ?int;
+
+    /**
+     * @param  int $algo
+     * @return MediaHashInterface
+     */
+    public function setAlgo(?int $algo) : MediaHashInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaInterface.php
+++ b/src/FeedIo/Feed/Item/MediaInterface.php
@@ -40,11 +40,6 @@ interface MediaInterface
     public function setNodeName(string $nodeName) : MediaInterface;
 
     /**
-     * @return bool
-     */
-    public function isThumbnail() : bool;
-
-    /**
      * @return string
      */
     public function getType() : ? string;

--- a/src/FeedIo/Feed/Item/MediaInterface.php
+++ b/src/FeedIo/Feed/Item/MediaInterface.php
@@ -95,13 +95,282 @@ interface MediaInterface
     public function setDescription(?string $description) : MediaInterface;
 
     /**
-     * @return string
+     * @return int
      */
-    public function getThumbnail() : ? string;
+    public function getRights() : ?int;
 
     /**
-     * @param  string $thumbnail
+     * @param  int $rights
      * @return MediaInterface
      */
-    public function setThumbnail(?string $thumbnail) : MediaInterface;
+    public function setRights(int $rights) : MediaInterface;
+
+
+
+    /**
+     * @return int
+     */
+    public function getTitleType() : ?int;
+
+    /**
+     * @param  string $titleType
+     * @return MediaInterface
+     */
+    public function setTitleType(?int $titleType) : MediaInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getDescriptionType() : ?int;
+
+    /**
+     * @param  string $descriptionType
+     * @return MediaInterface
+     */
+    public function setDescriptionType(?int $descriptionType) : MediaInterface;
+
+    /**
+     * @return array
+     */
+    public function getKeywords() : array;
+
+    /**
+     * @param  string $keywords
+     * @return MediaInterface
+     */
+    public function setKeywords(array $keywords) : MediaInterface;
+
+    /**
+     * @return array
+     */
+    public function getComments() : array;
+
+    /**
+     * @param  array $comments
+     * @return MediaInterface
+     */
+    public function setComments(array $comments) : MediaInterface;
+
+    /**
+     * @return array
+     */
+    public function getResponses() : array;
+
+    /**
+     * @param  string $responses
+     * @return MediaInterface
+     */
+    public function setResponses(array $responses) : MediaInterface;
+
+    /**
+     * @return array
+     */
+    public function getBacklinks() : array;
+
+    /**
+     * @param  string $backlinks
+     * @return MediaInterface
+     */
+    public function setBacklinks(array $backlinks) : MediaInterface;
+
+    /**
+     * @return array
+     */
+    public function getCredits() : array;
+
+    /**
+     * @param  string $credits
+     * @return MediaInterface
+     */
+    public function setCredits(array $credits) : MediaInterface;
+
+    /**
+     * @return array
+     */
+    public function getTexts() : array;
+
+    /**
+     * @param  string $texts
+     * @return MediaInterface
+     */
+    public function setTexts(array $texts) : MediaInterface;
+
+    /**
+     * @return array
+     */
+    public function getPrices() : array;
+
+    /**
+     * @param  string $prices
+     * @return MediaInterface
+     */
+    public function setPrices(array $prices) : MediaInterface;
+
+
+    /**
+     * @return array
+     */
+    public function getSubTitles() : array;
+
+    /**
+     * @param  string $subTitles
+     * @return MediaInterface
+     */
+    public function setSubTitles(array $subTitles) : MediaInterface;
+
+
+    /**
+     * @return array
+     */
+    public function getScenes() : array;
+
+    /**
+     * @param  string $scenes
+     * @return MediaInterface
+     */
+    public function setScenes(array $scenes) : MediaInterface;
+
+    /**
+     * @return MediaContentInterface
+     */
+    public function getContent() : MediaContentInterface;
+
+    /**
+     * @param  MediaContentInterface $content
+     * @return MediaInterface
+     */
+    public function setContent(MediaContentInterface $content) : MediaInterface;
+
+    /**
+     * @return MediaThumbnailInterface
+     */
+    public function getThumbnail() : MediaThumbnailInterface;
+
+    /**
+     * @param  MediaThumbnailInterface $content
+     * @return MediaInterface
+     */
+    public function setThumbnail(MediaThumbnailInterface $content) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getCategory() : MediaCategoryInterface;
+
+    /**
+     * @param  string $category
+     * @return MediaInterface
+     */
+    public function setCategory(MediaCategoryInterface $category) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getPlayer() : MediaPlayerInterface;
+
+    /**
+     * @param  string $player
+     * @return MediaInterface
+     */
+    public function setPlayer(MediaPlayerInterface $player) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getHash() : MediaHashInterface;
+
+    /**
+     * @param  string $hash
+     * @return MediaInterface
+     */
+    public function setHash(MediaHashInterface $hash) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getEmbed() : MediaEmbedInterface;
+
+    /**
+     * @param  string $embed
+     * @return MediaInterface
+     */
+    public function setEmbed(MediaEmbedInterface $embed) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getLicense() : MediaLicenseInterface;
+
+    /**
+     * @param  string $license
+     * @return MediaInterface
+     */
+    public function setLicense(MediaLicenseInterface $license) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getCommunity() : MediaCommunityInterface;
+
+    /**
+     * @param  string $community
+     * @return MediaInterface
+     */
+    public function setCommunity(MediaCommunityInterface $community) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getRestriction() : MediaRestrictionInterface;
+
+    /**
+     * @param  string $restriction
+     * @return MediaInterface
+     */
+    public function setRestriction(MediaRestrictionInterface $restriction) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getRating() : MediaRatingInterface;
+
+    /**
+     * @param  string $rating
+     * @return MediaInterface
+     */
+    public function setRating(MediaRatingInterface $rating) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getCopyright() : MediaCopyrightInterface;
+
+    /**
+     * @param  string $copyright
+     * @return MediaInterface
+     */
+    public function setCopyright(MediaCopyrightInterface $copyright) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getStatus() : MediaStatusInterface;
+
+    /**
+     * @param  string $status
+     * @return MediaInterface
+     */
+    public function setStatus(MediaStatusInterface $status) : MediaInterface;
+
+    /**
+     * @return string
+     */
+    public function getPeerLink() : MediaPeerLinkInterface;
+
+    /**
+     * @param  string $peerLink
+     * @return MediaInterface
+     */
+    public function setPeerLink(MediaPeerLinkInterface $peerLink) : MediaInterface;
 }

--- a/src/FeedIo/Feed/Item/MediaLicense.php
+++ b/src/FeedIo/Feed/Item/MediaLicense.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaLicense implements MediaLicenseInterface
+{
+    /**
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @return string
+     */
+    public function getContent() : ?string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param  string $content
+     * @return MediaLicenseInterface
+     */
+    public function setContent(?string $content) : MediaLicenseInterface
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl() : ?string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param  string $url
+     * @return MediaLicenseInterface
+     */
+    public function setUrl(?string $url) : MediaLicenseInterface
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType() : ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param  string $type
+     * @return MediaLicenseInterface
+     */
+    public function setType(?string $type) : MediaLicenseInterface
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaLicenseInterface.php
+++ b/src/FeedIo/Feed/Item/MediaLicenseInterface.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaLicenseInterface
+{
+    /**
+     * @return string
+     */
+    public function getContent() : ?string;
+
+    /**
+     * @param  string $content
+     * @return MediaLicenseInterface
+     */
+    public function setContent(?string $content) : MediaLicenseInterface;
+
+
+    /**
+     * @return string
+     */
+    public function getUrl() : ?string;
+
+    /**
+     * @param  string $url
+     * @return MediaLicenseInterface
+     */
+    public function setUrl(?string $url) : MediaLicenseInterface;
+
+
+    /**
+     * @return string
+     */
+    public function getType() : ?string;
+
+    /**
+     * @param  string $type
+     * @return MediaLicenseInterface
+     */
+    public function setType(?string $type) : MediaLicenseInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaPeerLink.php
+++ b/src/FeedIo/Feed/Item/MediaPeerLink.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaPeerLink implements MediaPeerLinkInterface
+{
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @return string
+     */
+    public function getUrl() : ?string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param  string $url
+     * @return MediaPeerLinkInterface
+     */
+    public function setUrl(?string $url) : MediaPeerLinkInterface
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType() : ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param  string $type
+     * @return MediaPeerLinkInterface
+     */
+    public function setType(?string $type) : MediaPeerLinkInterface
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaPeerLinkInterface.php
+++ b/src/FeedIo/Feed/Item/MediaPeerLinkInterface.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaPeerLinkInterface
+{
+    /**
+     * @return string
+     */
+    public function getUrl() : ?string;
+
+    /**
+     * @param  string $url
+     * @return MediaPeerLinkInterface
+     */
+    public function setUrl(?string $url) : MediaPeerLinkInterface;
+
+    /**
+     * @return string
+     */
+    public function getType() : ?string;
+
+    /**
+     * @param  string $type
+     * @return MediaPeerLinkInterface
+     */
+    public function setType(?string $type) : MediaPeerLinkInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaPlayer.php
+++ b/src/FeedIo/Feed/Item/MediaPlayer.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaPlayer implements MediaPlayerInterface
+{
+    /**
+     * @var string
+     */
+    protected $playerUrl;
+
+    /**
+     * @var int
+     */
+    protected $playerWidth;
+
+    /**
+     * @var int
+     */
+    protected $playerHeight;
+
+    /**
+     * @return string
+     */
+    public function getUrl() : ?string
+    {
+        return $this->playerUrl;
+    }
+
+    /**
+     * @param  string $playerUrl
+     * @return MediaPlayerInterface
+     */
+    public function setUrl(?string $playerUrl) : MediaPlayerInterface
+    {
+        $this->playerUrl = $playerUrl;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getWidth() : ?int
+    {
+        return $this->playerWidth;
+    }
+
+    /**
+     * @param  int $playerWidth
+     * @return MediaPlayerInterface
+     */
+    public function setWidth(?int $playerWidth) : MediaPlayerInterface
+    {
+        $this->playerWidth = $playerWidth;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getHeight() : ?int
+    {
+        return $this->playerHeight;
+    }
+
+    /**
+     * @param  int $playerHeight
+     * @return MediaPlayerInterface
+     */
+    public function setHeight(?int $playerHeight) : MediaPlayerInterface
+    {
+        $this->playerHeight = $playerHeight;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaPlayerInterface.php
+++ b/src/FeedIo/Feed/Item/MediaPlayerInterface.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaPlayerInterface
+{
+    /**
+     * @return string
+     */
+    public function getUrl() : ?string;
+
+    /**
+     * @param  string $playerUrl
+     * @return MediaPlayerInterface
+     */
+    public function setUrl(?string $playerUrl) : MediaPlayerInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getWidth() : ?int;
+
+    /**
+     * @param  string $playerWidth
+     * @return MediaPlayerInterface
+     */
+    public function setWidth(?int $playerWidth) : MediaPlayerInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getHeight() : ?int;
+
+    /**
+     * @param  string $playerHeight
+     * @return MediaPlayerInterface
+     */
+    public function setHeight(?int $playerHeight) : MediaPlayerInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaPrice.php
+++ b/src/FeedIo/Feed/Item/MediaPrice.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+abstract class MediaPriceType extends MediaConstant
+{
+    const Free = 1;
+    const Rent = 2;
+    const Purchase = 3;
+    const Package = 4;
+    const Subscription = 5;
+
+    const VALUES = array(
+        "free" => MediaPriceType::Free,
+        "rent" => MediaPriceType::Rent,
+        "purchase" => MediaPriceType::Purchase,
+        "package" => MediaPriceType::Package,
+        "subscription" => MediaPriceType::Subscription,
+    );
+}
+
+
+class MediaPrice
+{
+    /**
+     * @var int
+     */
+    protected $type;
+
+    /**
+     * @var float
+     */
+    protected $value;
+
+    /**
+     * @var string
+     */
+    protected $currency;
+
+    /**
+     * @param  int $type
+     * @return MediaPrice
+     */
+    public function setType(? int $type) : MediaPrice
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getType() : ? int
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param  float $value
+     * @return MediaPrice
+     */
+    public function setValue(? float $value) : MediaPrice
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    public function getValue() : ? float
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param  string|null currency
+     * @return MediaPrice
+     */
+    public function setCurrency(? string $currency) : MediaPrice
+    {
+        $this->currency = $currency;
+        return $this;
+    }
+
+    public function getCurrency() : ? string
+    {
+        return $this->currency;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaRating.php
+++ b/src/FeedIo/Feed/Item/MediaRating.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaRating implements MediaRatingInterface
+{
+    /**
+     * @var string
+     */
+    protected $content;
+
+
+    /**
+     * @var string
+     */
+    protected $scheme;
+
+
+    /**
+     * @return string
+     */
+    public function getContent() : ?string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param  string $content
+     * @return MediaRatingInterface
+     */
+    public function setContent(?string $content) : MediaRatingInterface
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getScheme() : ?string
+    {
+        return $this->scheme;
+    }
+
+    /**
+     * @param  string $scheme
+     * @return MediaRatingInterface
+     */
+    public function setScheme(?string $scheme) : MediaRatingInterface
+    {
+        $this->scheme = $scheme;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaRatingInterface.php
+++ b/src/FeedIo/Feed/Item/MediaRatingInterface.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaRatingInterface
+{
+    /**
+     * @return string
+     */
+    public function getContent() : ?string;
+
+    /**
+     * @param  string $rating
+     * @return MediaRatingInterface
+     */
+    public function setContent(?string $rating) : MediaRatingInterface;
+
+
+    /**
+     * @return string
+     */
+    public function getScheme() : ?string;
+
+    /**
+     * @param  string $scheme
+     * @return MediaRatingInterface
+     */
+    public function setScheme(?string $scheme) : MediaRatingInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaRestriction.php
+++ b/src/FeedIo/Feed/Item/MediaRestriction.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+abstract class MediaRestrictionRelationship extends MediaConstant
+{
+    const Allow = 1;
+    const Deny = 2;
+
+    const VALUES = array(
+        "allow" => MediaRestrictionRelationship::Allow,
+        "deny" => MediaRestrictionRelationship::Deny,
+    );
+}
+
+abstract class MediaRestrictionType extends MediaConstant
+{
+    const Country = 1;
+    const URI = 2;
+    const Sharing = 3;
+
+    const VALUES = array(
+        null => MediaRestrictionType::Sharing,
+        "country" => MediaRestrictionType::Country,
+        "uri" => MediaRestrictionType::URI,
+        "sharing" => MediaRestrictionType::Sharing,
+    );
+}
+
+
+class MediaRestriction implements MediaRestrictionInterface
+{
+
+    /**
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * @var int
+     */
+    protected $type;
+
+    /**
+     * @var int
+     */
+    protected $relationship;
+
+
+    /**
+     * @return string
+     */
+    public function getContent() : ?string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param  string $content
+     * @return MediaRestrictionInterface
+     */
+    public function setContent(?string $content) : MediaRestrictionInterface
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+
+    /**
+     * @return int
+     */
+    public function getType() : ?int
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param  int $type
+     * @return MediaRestrictionInterface
+     */
+    public function setType(?int $type) : MediaRestrictionInterface
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRelationship() : ?int
+    {
+        return $this->relationship;
+    }
+
+    /**
+     * @param  int $relationship
+     * @return MediaRestrictionInterface
+     */
+    public function setRelationship(?int $relationship) : MediaRestrictionInterface
+    {
+        $this->relationship = $relationship;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaRestrictionInterface.php
+++ b/src/FeedIo/Feed/Item/MediaRestrictionInterface.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaRestrictionInterface
+{
+    /**
+     * @return string
+     */
+    public function getContent() : ?string;
+
+    /**
+     * @param  string $content
+     * @return MediaRestrictionInterface
+     */
+    public function setContent(?string $content) : MediaRestrictionInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getType() : ?int;
+
+    /**
+     * @param  string $type
+     * @return MediaRestrictionInterface
+     */
+    public function setType(?int $type) : MediaRestrictionInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getRelationship() : ?int;
+
+    /**
+     * @param  string $relationship
+     * @return MediaRestrictionInterface
+     */
+    public function setRelationship(?int $relationship) : MediaRestrictionInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaScene.php
+++ b/src/FeedIo/Feed/Item/MediaScene.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaScene
+{
+    /**
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * @var \DateTime
+     */
+    protected $startTime;
+
+    /**
+     * @var \DateTime
+     */
+    protected $endTime;
+
+    /**
+     * @param  string $title
+     * @return MediaScene
+     */
+    public function setTitle(string $title) : MediaScene
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getTitle() : string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param  string $description
+     * @return MediaScene
+     */
+    public function setDescription(? string $description) : MediaScene
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getDescription() : ? string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param  \DateTime $startTime
+     * @return MediaScene
+     */
+    public function setStartTime(? \DateTime $startTime) : MediaScene
+    {
+        $this->startTime = $startTime;
+        return $this;
+    }
+
+    public function getStartTime() : ? \DateTime
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * @param  \DateTime $endTime
+     * @return MediaScene
+     */
+    public function setEndTime(? \DateTime $endTime) : MediaScene
+    {
+        $this->endTime = $endTime;
+        return $this;
+    }
+
+    public function getEndTime() : ? \DateTime
+    {
+        return $this->endTime;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaStatus.php
+++ b/src/FeedIo/Feed/Item/MediaStatus.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+abstract class MediaStatusValue extends MediaConstant
+{
+    const Active = 1;
+    const Blocked = 2;
+    const Deleted = 3;
+
+    const VALUES = array(
+        "active" => MediaStatusValue::Active,
+        "blocked" => MediaStatusValue::Blocked,
+        "deleted" => MediaStatusValue::Deleted,
+    );
+}
+
+
+abstract class MediaRightsStatus extends MediaConstant
+{
+    const UserCreated = 1;
+    const Official = 2;
+
+    const VALUES = array(
+        "usercreated" => MediaRightsStatus::UserCreated,
+        "official" => MediaRightsStatus::Official,
+    );
+}
+
+
+class MediaStatus implements MediaStatusInterface
+{
+    /**
+     * @var int
+     */
+    protected $value;
+
+    /**
+     * @var string
+     */
+    protected $reason;
+
+    /**
+     * @return int
+     */
+    public function getValue() : ?int
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param  int $value
+     * @return MediaValueInterface
+     */
+    public function setValue(?int $value) : MediaStatusInterface
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReason() : ?string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * @param  string $reason
+     * @return MediaStatusInterface
+     */
+    public function setReason(?string $reason) : MediaStatusInterface
+    {
+        $this->reason = $reason;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaStatusInterface.php
+++ b/src/FeedIo/Feed/Item/MediaStatusInterface.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaStatusInterface
+{
+    /**
+     * @return int
+     */
+    public function getValue() : ?int;
+
+    /**
+     * @param  int $value
+     * @return MediaValueInterface
+     */
+    public function setValue(?int $value) : MediaStatusInterface;
+
+    /**
+     * @return string
+     */
+    public function getReason() : ?string;
+
+    /**
+     * @param  string $reason
+     * @return MediaStatusInterface
+     */
+    public function setReason(?string $reason) : MediaStatusInterface;
+}

--- a/src/FeedIo/Feed/Item/MediaSubtitle.php
+++ b/src/FeedIo/Feed/Item/MediaSubtitle.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaSubtitle
+{
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var string
+     */
+    protected $lang;
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @param  string $type
+     * @return MediaSubtitle
+     */
+    public function setType(? string $type) : MediaSubtitle
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getType() : ? string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param  string $lang
+     * @return MediaSubtitle
+     */
+    public function setLang(? string $lang) : MediaSubtitle
+    {
+        $this->lang = $lang;
+        return $this;
+    }
+
+    public function getLang() : ? string
+    {
+        return $this->lang;
+    }
+
+    /**
+     * @param  string|null url
+     * @return MediaSubtitle
+     */
+    public function setUrl(? string $url) : MediaSubtitle
+    {
+        $this->url = $url;
+        return $this;
+    }
+
+    public function getUrl() : ? string
+    {
+        return $this->url;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaText.php
+++ b/src/FeedIo/Feed/Item/MediaText.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+abstract class MediaTextType extends MediaConstant
+{
+    const Plain = 1;
+    const HTML = 2;
+
+    const VALUES = array(
+        null => MediaTextType::Plain,
+        "plain" => MediaTextType::Plain,
+        "html" => MediaTextType::HTML,
+    );
+}
+
+
+class MediaText
+{
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * @var int
+     */
+    protected $type;
+
+    /**
+     * @var string
+     */
+    protected $lang;
+
+    /**
+     * @var \DateTime
+     */
+    protected $start;
+
+    /**
+     * @var \DateTime
+     */
+    protected $end;
+
+    /**
+     * @param  string $value
+     * @return MediaText
+     */
+    public function setValue(string $value) : MediaText
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    public function getValue() : string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param  int $type
+     * @return MediaText
+     */
+    public function setType(int $type) : MediaText
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getType() : int
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param  string $lang
+     * @return MediaText
+     */
+    public function setLang(? string $lang) : MediaText
+    {
+        $this->lang = $lang;
+        return $this;
+    }
+
+    public function getLang() : ? string
+    {
+        return $this->lang;
+    }
+
+    /**
+     * @param  \DateTime $start
+     * @return MediaText
+     */
+    public function setStart(? \DateTime $start) : MediaText
+    {
+        $this->start = $start;
+        return $this;
+    }
+
+    public function getStart() : ? \DateTime
+    {
+        return $this->start;
+    }
+
+    /**
+     * @param  \DateTime $end
+     * @return MediaText
+     */
+    public function setEnd(? \DateTime $end) : MediaText
+    {
+        $this->end = $end;
+        return $this;
+    }
+
+    public function getEnd() : ? \DateTime
+    {
+        return $this->end;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaThumbnail.php
+++ b/src/FeedIo/Feed/Item/MediaThumbnail.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+class MediaThumbnail implements MediaThumbnailInterface
+{
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @var int
+     */
+    protected $width;
+
+    /**
+     * @var int
+     */
+    protected $height;
+
+    /**
+     * @var \DateTime
+     */
+    protected $time;
+
+
+    /**
+     * @return string
+     */
+    public function getUrl() : ? string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param  string $url
+     * @return MediaThumbnailInterface
+     */
+    public function setUrl(?string $url) : MediaThumbnailInterface
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getWidth() : ?int
+    {
+        return $this->width;
+    }
+
+    /**
+     * @param  int $width
+     * @return MediaThumbnailInterface
+     */
+    public function setWidth(?int $width) : MediaThumbnailInterface
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getHeight() : ?int
+    {
+        return $this->height;
+    }
+
+    /**
+     * @param  int $height
+     * @return MediaThumbnailInterface
+     */
+    public function setHeight(?int $height) : MediaThumbnailInterface
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getTime() : ? \DateTime
+    {
+        return $this->time;
+    }
+
+    /**
+     * @param  \DateTime $time
+     * @return MediaThumbnailInterface
+     */
+    public function setTime(? \DateTime $time) : MediaThumbnailInterface
+    {
+        $this->time = $time;
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Feed/Item/MediaThumbnailInterface.php
+++ b/src/FeedIo/Feed/Item/MediaThumbnailInterface.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Feed\Item;
+
+interface MediaThumbnailInterface
+{
+
+    /**
+     * @return string
+     */
+    public function getUrl() : ? string;
+
+    /**
+     * @param  string $thumbnail
+     * @return MediaThumbnailInterface
+     */
+    public function setUrl(?string $thumbnail) : MediaThumbnailInterface;
+
+    /**
+     * @return int
+     */
+    public function getWidth() : ?int;
+
+    /**
+     * @param  string $width
+     * @return MediaThumbnailInterface
+     */
+    public function setWidth(?int $width) : MediaThumbnailInterface;
+
+
+    /**
+     * @return int
+     */
+    public function getHeight() : ?int;
+
+    /**
+     * @param  string $height
+     * @return MediaThumbnailInterface
+     */
+    public function setHeight(?int $height) : MediaThumbnailInterface;
+
+
+    /**
+     * @return DateTime
+     */
+    public function getTime() : ? \DateTime;
+
+    /**
+     * @param  string $time
+     * @return MediaThumbnailInterface
+     */
+    public function setTime(? \DateTime $time) : MediaThumbnailInterface;
+}

--- a/src/FeedIo/Rule/Media.php
+++ b/src/FeedIo/Rule/Media.php
@@ -10,9 +10,38 @@
 
 namespace FeedIo\Rule;
 
-use FeedIo\Feed\Item;
 use FeedIo\Feed\Item\MediaInterface;
 use FeedIo\Feed\ItemInterface;
+use FeedIo\Feed\Item\MediaCategory;
+use FeedIo\Feed\Item\MediaCommunity;
+use FeedIo\Feed\Item\MediaContent;
+use FeedIo\Feed\Item\MediaContentMedium;
+use FeedIo\Feed\Item\MediaContentExpression;
+use FeedIo\Feed\Item\MediaCopyright;
+use FeedIo\Feed\Item\MediaDescriptionType;
+use FeedIo\Feed\Item\MediaEmbed;
+use FeedIo\Feed\Item\MediaTitleType;
+use FeedIo\Feed\Item\MediaHash;
+use FeedIo\Feed\Item\MediaHashAlgo;
+use FeedIo\Feed\Item\MediaLicense;
+use FeedIo\Feed\Item\MediaCreditScheme;
+use FeedIo\Feed\Item\MediaPeerLink;
+use FeedIo\Feed\Item\MediaPriceType;
+use FeedIo\Feed\Item\MediaPlayer;
+use FeedIo\Feed\Item\MediaTextType;
+use FeedIo\Feed\Item\MediaRating;
+use FeedIo\Feed\Item\MediaRestriction;
+use FeedIo\Feed\Item\MediaRestrictionRelationship;
+use FeedIo\Feed\Item\MediaRestrictionType;
+use FeedIo\Feed\Item\MediaRightsStatus;
+use FeedIo\Feed\Item\MediaStatus;
+use FeedIo\Feed\Item\MediaStatusValue;
+use FeedIo\Feed\Item\MediaCredit;
+use FeedIo\Feed\Item\MediaPrice;
+use FeedIo\Feed\Item\MediaSubtitle;
+use FeedIo\Feed\Item\MediaText;
+use FeedIo\Feed\Item\MediaThumbnail;
+use FeedIo\Feed\Item\MediaScene;
 use FeedIo\Feed\NodeInterface;
 use FeedIo\Parser\UrlGenerator;
 use FeedIo\RuleAbstract;
@@ -111,9 +140,9 @@ class Media extends RuleAbstract
     }
 
     /**
-     * @param \NodeInterface $node
+     * @param NodeInterface $node
      * @param \DomElement $element
-     * @return \MediaInterface
+     * @return void
      */
     protected function handleMediaGroup(NodeInterface $node, \DOMElement $element): void
     {
@@ -125,9 +154,9 @@ class Media extends RuleAbstract
     }
 
     /**
-     * @param \NodeInterface $node
+     * @param NodeInterface $node
      * @param \DomElement $element
-     * @return \MediaInterface
+     * @return void
      */
     protected function handleMediaRoot(NodeInterface $node, \DOMElement $element): void
     {
@@ -138,9 +167,30 @@ class Media extends RuleAbstract
         $this->handleMediaContent($element, $media);
 
         $tags = array(
+            'media:rating' => 'handleMediaRating',
             'media:title' => 'handleMediaTitle',
             'media:description' => 'handleMediaDescription',
+            'media:keywords' => 'handleMediaKeywords',
             'media:thumbnail' => 'handleMediaThumbnail',
+            'media:category' => 'handleMediaCategory',
+            'media:hash' => 'handleMediaHash',
+            'media:player' => 'handleMediaPlayer',
+            'media:credit' => 'handleMediaCredit',
+            'media:copyright' => 'handleMediaCopyright',
+            'media:text' => 'handleMediaText',
+            'media:restriction' => 'handleMediaRestriction',
+            'media:community' => 'handleMediaCommunity',
+            'media:comments' => 'handleMediaComments',
+            'media:embed' => 'handleMediaEmbed',
+            'media:responses' => 'handleMediaResponses',
+            'media:backLinks' => 'handleMediaBacklinks',
+            'media:status' => 'handleMediaStatus',
+            'media:price' => 'handleMediaPrice',
+            'media:license' => 'handleMediaLicense',
+            'media:subTitle' => 'handleMediaSubtitle',
+            'media:peerLink' => 'handleMediaPeerlink',
+            'media:rights' => 'handleMediaRights',
+            'media:scenes' => 'handleMediaScenes',
         );
 
         foreach ($tags as $tag => $callback) {
@@ -153,30 +203,501 @@ class Media extends RuleAbstract
         $node->addMedia($media);
     }
 
+    /**
+     * @param \DomElement $element
+     * @param MediaInterface $media
+     * @return void
+     */
     protected function handleMediaContent(?\DOMElement $element, MediaInterface $media) : void
     {
         $media->setUrl($this->getAttributeValue($element, "url"));
+        $media->setType($this->getAttributeValue($element, "type"));
+
+        $content = new MediaContent();
+        $content->setFileSize(intval($this->getAttributeValue($element, "fileSize")));
+        $content->setBitrate(intval($this->getAttributeValue($element, "bitrate")));
+        $content->setFramerate(intval($this->getAttributeValue($element, "framerate")));
+        $content->setSamplingrate(floatval($this->getAttributeValue($element, "samplingrate")));
+        $content->setDuration(intval($this->getAttributeValue($element, "duration")));
+        $content->setHeight(intval($this->getAttributeValue($element, "height")));
+        $content->setWidth(intval($this->getAttributeValue($element, "width")));
+        $content->setLang($this->getAttributeValue($element, "lang"));
+        $content->setExpression(MediaContentExpression::fromXML(
+            $this->getAttributeValue($element, "expression")
+        ));
+        $content->setMedium(
+            MediaContentMedium::fromXML(
+                $this->getAttributeValue($element, "medium")
+            )
+        );
+
+        switch ($this->getAttributeValue($element, "isDefault")) {
+            case "true":
+                $content->setDefault(true);
+                break;
+            case "false":
+                $content->setDefault(false);
+                break;
+        }
+        $media->setContent($content);
     }
 
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaRating(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $rating = new MediaRating();
+
+        $rating->setContent($element->nodeValue);
+        $rating->setScheme($this->getAttributeValue($element, "scheme") ?: 'urn:simple');
+
+        $media->setRating($rating);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
     protected function handleMediaTitle(?\DOMNodeList $elements, MediaInterface $media) : void
     {
         $element = $elements->item(0);
 
         $media->setTitle($element->nodeValue);
+        $media->setTitleType(MediaTitleType::fromXML(
+            $this->getAttributeValue($element, "type")
+        ));
     }
 
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
     protected function handleMediaDescription(?\DOMNodeList $elements, MediaInterface $media) : void
     {
         $element = $elements->item(0);
 
         $media->setDescription($element->nodeValue);
+        $media->setDescriptionType(MediaDescriptionType::fromXML(
+            $this->getAttributeValue($element, "type")
+        ));
     }
 
-    protected function handleMediaThumbnail(?\DOMNodeList $elements, MediaInterface $media) : void
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaKeywords(?\DOMNodeList $elements, MediaInterface $media) : void
     {
         $element = $elements->item(0);
 
-        $media->setThumbnail($this->getAttributeValue($element, "url"));
+        $media->setKeywords(array_map("trim", explode(
+            ',',
+            $element->nodeValue
+        )));
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaThumbnail(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $thumbnail = new MediaThumbnail();
+
+        $thumbnail->setUrl($this->getAttributeValue($element, "url"));
+        $thumbnail->setWidth(intval($this->getAttributeValue($element, "width")));
+        $thumbnail->setHeight(intval($this->getAttributeValue($element, "height")));
+        if ($element->hasAttribute("time")) {
+            $thumbnail->setTime(new \DateTime($this->getAttributeValue($element, "time")));
+        }
+
+        $media->setThumbnail($thumbnail);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaCategory(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $category = new MediaCategory();
+
+        $category->setText($element->nodeValue);
+        $category->setLabel($this->getAttributeValue($element, "label"));
+        $default_scheme = "http://search.yahoo.com/mrss/category_schema";
+        $category->setScheme($this->getAttributeValue($element, "scheme") ?: $default_scheme);
+
+        $media->setCategory($category);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaHash(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $hash = new MediaHash();
+
+        $hash->setContent($element->nodeValue);
+        $hash->setAlgo(MediaHashAlgo::fromXML($this->getAttributeValue($element, "algo")));
+
+        $media->setHash($hash);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaPlayer(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $player = new MediaPlayer();
+
+        $player->setUrl($this->getAttributeValue($element, "url"));
+        $player->setWidth(intval($this->getAttributeValue($element, "width")));
+        $player->setHeight(intval($this->getAttributeValue($element, "height")));
+
+        $media->setPlayer($player);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaCredit(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $credits = array();
+        foreach ($elements as $element) {
+            $credit = new MediaCredit();
+
+            $credit->setValue($element->nodeValue);
+            $credit->setScheme(MediaCreditScheme::fromXML($this->getAttributeValue($element, "scheme")));
+            $credit->setRole($this->getAttributeValue($element, "role"));
+            array_push($credits, $credit);
+        }
+        $media->setCredits($credits);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaCopyright(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $copyright = new MediaCopyright();
+
+        $copyright->setContent($element->nodeValue);
+        $copyright->setUrl($this->getAttributeValue($element, "url"));
+
+        $media->setCopyright($copyright);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaText(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $texts = array();
+        foreach ($elements as $element) {
+            $text = new MediaText();
+
+            $text->setValue($element->nodeValue);
+            $text->setType(MediaTextType::fromXML($this->getAttributeValue($element, "type")));
+            $text->setLang($this->getAttributeValue($element, "lang"));
+            if ($element->hasAttribute("start")) {
+                $text->setStart(new \DateTime($this->getAttributeValue($element, "start")));
+            }
+            if ($element->hasAttribute("end")) {
+                $text->setEnd(new \DateTime($this->getAttributeValue($element, "end")));
+            }
+            array_push($texts, $text);
+        }
+        $media->setTexts($texts);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaRestriction(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $restriction = new MediaRestriction();
+
+        $restriction->setContent($element->nodeValue);
+        $restriction->setType(MediaRestrictionType::fromXML($this->getAttributeValue($element, "type")));
+        $restriction->setRelationship(MediaRestrictionRelationship::fromXML($this->getAttributeValue($element, "relationship")));
+
+        $media->setRestriction($restriction);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaCommunity(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $community = new MediaCommunity();
+
+        $community->setStarRatingAverage(floatval($this->getChildAttributeValue($element, "starRating", "average", static::MRSS_NAMESPACE)));
+        $community->setStarRatingCount(intval($this->getChildAttributeValue($element, "starRating", "count", static::MRSS_NAMESPACE)));
+        $community->setStarRatingMin(intval($this->getChildAttributeValue($element, "starRating", "min", static::MRSS_NAMESPACE)));
+        $community->setStarRatingMax(intval($this->getChildAttributeValue($element, "starRating", "max", static::MRSS_NAMESPACE)));
+        $community->setNbViews(intval($this->getChildAttributeValue($element, "statistics", "views", static::MRSS_NAMESPACE)));
+        $community->setNbFavorites(intval($this->getChildAttributeValue($element, "statistics", "favorites", static::MRSS_NAMESPACE)));
+
+        $tags = array();
+        $tagsValue = $this->getChildValue($element, "tags", static::MRSS_NAMESPACE);
+        if ($tagsValue) {
+            foreach (explode(",", $tagsValue) as $pair) {
+                $values = explode(":", $pair);
+                if (count($values) != 2) {
+                    continue;
+                }
+                $key = trim($values[0]);
+                $value = intval($values[1]);
+                $tags[$key] = $value;
+            }
+        }
+        $community->setTags($tags);
+
+        $media->setCommunity($community);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaComments(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+
+        $comments = array();
+        foreach ($element->childNodes as $node) {
+            if (is_a($node, "DOMNode") && $node->nodeName == "media:comment") {
+                array_push($comments, $node->nodeValue);
+            }
+        }
+        $media->setComments($comments);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaEmbed(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $embed = new MediaEmbed();
+
+        $embed->setUrl($this->getAttributeValue($element, "url"));
+        $embed->setWidth(intval($this->getAttributeValue($element, "width")));
+        $embed->setHeight(intval($this->getAttributeValue($element, "height")));
+
+        $params = array();
+        foreach ($element->childNodes as $node) {
+            if (is_a($node, "DOMNode") && $node->nodeName == "media:param") {
+                $key = $this->getAttributeValue($node, "name");
+                $value = $node->nodeValue;
+                $params[$key] = trim($value);
+            }
+        }
+
+        $embed->setParams($params);
+
+        $media->setEmbed($embed);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaResponses(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+
+        $responses = array();
+        foreach ($element->childNodes as $node) {
+            if (is_a($node, "DOMNode") && $node->nodeName == "media:response") {
+                array_push($responses, $node->nodeValue);
+            }
+        }
+        $media->setResponses($responses);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaBacklinks(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+
+        $backlinks = array();
+        foreach ($element->childNodes as $node) {
+            if (is_a($node, "DOMNode") && $node->nodeName == "media:backLink") {
+                array_push($backlinks, $node->nodeValue);
+            }
+        }
+        $media->setBacklinks($backlinks);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaStatus(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $status = new MediaStatus();
+
+        $status->setValue(MediaStatusValue::fromXML($this->getAttributeValue($element, "state")));
+        $status->setReason($this->getAttributeValue($element, "reason"));
+
+        $media->setStatus($status);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaPrice(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $prices = array();
+        foreach ($elements as $element) {
+            $price = new MediaPrice();
+
+            $price->setType(MediaPriceType::fromXML($this->getAttributeValue($element, "type")));
+            $price->setValue(floatval($this->getAttributeValue($element, "price")));
+            $price->setCurrency($this->getAttributeValue($element, "currency"));
+            array_push($prices, $price);
+        }
+        $media->setPrices($prices);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaLicense(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $license = new MediaLicense();
+
+        $license->setContent($element->nodeValue);
+        $license->setUrl($this->getAttributeValue($element, "href"));
+        $license->setType($this->getAttributeValue($element, "type"));
+
+        $media->setLicense($license);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaSubtitle(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $subtitles = array();
+        foreach ($elements as $element) {
+            $subtitle = new MediaSubtitle();
+
+            $subtitle->setType($this->getAttributeValue($element, "type"));
+            $subtitle->setLang($this->getAttributeValue($element, "lang"));
+            $subtitle->setUrl($this->getAttributeValue($element, "href"));
+            array_push($subtitles, $subtitle);
+        }
+        $media->setSubTitles($subtitles);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaPeerlink(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+        $peerLink = new MediaPeerLink();
+
+        $peerLink->setUrl($this->getAttributeValue($element, "href"));
+        $peerLink->setType($this->getAttributeValue($element, "type"));
+
+        $media->setPeerLink($peerLink);
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaRights(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+
+        $media->setRights(MediaRightsStatus::fromXML($this->getAttributeValue($element, "status")));
+    }
+
+    /**
+     * @param \DomElement $elements
+     * @param MediaInterface $media
+     * @return void
+     */
+    protected function handleMediaScenes(?\DOMNodeList $elements, MediaInterface $media) : void
+    {
+        $element = $elements->item(0);
+
+        $scenes = array();
+        foreach ($element->childNodes as $node) {
+            if (is_a($node, "DOMNode") && $node->nodeName == "media:scene") {
+                $scene = new MediaScene();
+
+                $scene->setTitle($this->getChildValue($node, "sceneTitle"));
+                $scene->setDescription($this->getChildValue($node, "sceneDescription"));
+                $startTime = $this->getChildValue($node, "sceneStartTime");
+                $endTime = $this->getChildValue($node, "sceneEndTime");
+
+                if ($startTime !== null) {
+                    $scene->setStartTime(new \DateTime($startTime));
+                }
+
+                if ($endTime !== null) {
+                    $scene->setEndTime(new \DateTime($endTime));
+                }
+
+                array_push($scenes, $scene);
+            }
+        }
+        $media->setScenes($scenes);
     }
 
     /**

--- a/src/FeedIo/Standard/Rss.php
+++ b/src/FeedIo/Standard/Rss.php
@@ -108,7 +108,6 @@ class Rss extends XmlAbstract
             ->add(new Author(), ['dc:creator'])
             ->add(new PublicId())
             ->add($this->getModifiedSinceRule(static::DATE_NODE_TAGNAME), ['lastBuildDate', 'lastPubDate'])
-            ->add(new Media(), ['media:thumbnail'])
             ->add(new Media(), ['media:group'])
             ->add(new Media(), ['media:content'])
             ;

--- a/tests/FeedIo/Feed/ItemTest.php
+++ b/tests/FeedIo/Feed/ItemTest.php
@@ -195,6 +195,31 @@ class ItemTest extends TestCase
                               'description' => null,
                               'thumbnail'   => null,
                               'length'      => null,
-                              'nodeName'    => null]], $out['medias']);
+                              'nodeName'    => null,
+                              'rights' => null,
+                              'titleType' => null,
+                              'descriptionType' => null,
+                              'keywords' => Array (),
+                              'comments' => Array (),
+                              'responses' => Array (),
+                              'backlinks' => Array (),
+                              'credits' => Array (),
+                              'texts' => Array (),
+                              'prices' => Array (),
+                              'subTitles' => Array (),
+                              'scenes' => Array (),
+                              'content' => null,
+                              'category' => null,
+                              'hash' => null,
+                              'embed' => null,
+                              'license' => null,
+                              'community' => null,
+                              'restriction' => null,
+                              'rating' => null,
+                              'copyright' => null,
+                              'player' => null,
+                              'status' => null,
+                              'peerLink' => null]], $out['medias']
+                            );
     }
 }

--- a/tests/FeedIo/Parser/MediaRSSTest.php
+++ b/tests/FeedIo/Parser/MediaRSSTest.php
@@ -6,11 +6,28 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ *
+ * The Media-RSS specification is available here:
+ * http://www.rssboard.org/media-rss
  */
 
 namespace FeedIo\Parser;
 
 use FeedIo\Feed;
+use FeedIo\Feed\Item\MediaConstants;
+use FeedIo\Feed\Item\MediaContentMedium;
+use FeedIo\Feed\Item\MediaContentExpression;
+use FeedIo\Feed\Item\MediaDescriptionType;
+use FeedIo\Feed\Item\MediaTitleType;
+use FeedIo\Feed\Item\MediaHashAlgo;
+use FeedIo\Feed\Item\MediaCreditScheme;
+use FeedIo\Feed\Item\MediaPriceType;
+use FeedIo\Feed\Item\MediaRestrictionRelationship;
+use FeedIo\Feed\Item\MediaRestrictionType;
+use FeedIo\Feed\Item\MediaRightsStatus;
+use FeedIo\Feed\Item\MediaStatusValue;
+use FeedIo\Feed\Item\MediaTextType;
+use FeedIo\Feed\Item\MediaThumbnail;
 use FeedIo\Parser\XmlParser as Parser;
 use FeedIo\Reader\Document;
 use FeedIo\Rule\DateTimeBuilder;
@@ -51,6 +68,25 @@ class MediaRssTest extends TestCase
         return $this->getMediaFromFeed($feed, $nb);
     }
 
+    protected function getMediaFromXMLSample($sample)
+    {
+        return $this->getMediaFromXML('
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Title of page</title>
+                    <link>http://www.foo.com</link>
+                    <description>Description of page</description>
+                    <item>
+                        <title>Story about something</title>
+                        <link>http://www.foo.com/item1.htm</link>
+                        <media:content url="http://www.foo.com/trailer.ogg">'.
+                            $sample.
+                        '</media:content>
+                    </item>
+                </channel>
+            </rss>');
+    }
+
     protected function getMediaFromFeed($feed, $nb=1)
     {
         $this->assertEquals(1, count($feed));
@@ -71,7 +107,7 @@ class MediaRssTest extends TestCase
     {
         $media = $this->getMediaFromFile(static::YOUTUBE_SAMPLE_FILE);
         $this->assertEquals('YT_VIDEO_TITLE', $media->getTitle());
-        $this->assertEquals('https://i2.ytimg.com/vi/YT_VIDEO_ID/hqdefault.jpg', $media->getThumbnail());
+        $this->assertEquals('https://i2.ytimg.com/vi/YT_VIDEO_ID/hqdefault.jpg', $media->getThumbnail()->getUrl());
         $this->assertEquals("This is a\nmultiline\ndescription", $media->getDescription());
         $this->assertEquals('https://www.youtube.com/v/YT_VIDEO_ID?version=3', $media->getUrl());
     }
@@ -226,5 +262,991 @@ class MediaRssTest extends TestCase
         $this->assertEquals('Supersong in OGG', $supersong_ogg->getDescription());
         $this->assertEquals('Supersong in FLAC', $supersong_flac->getDescription());
         $this->assertEquals('Hypersong in FLAC', $hypersong->getDescription());
+    }
+
+    /**
+     * media:content
+     *
+     * <media:content> is a sub-element of either <item> or <media:group>. Media objects that are not the same content should not be included in the same <media:group> element. The sequence of these items implies the order of presentation. While many of the attributes appear to be audio/video specific, this element can be used to publish any type of media. It contains 14 attributes, most of which are optional.
+     *
+     * <media:content
+     *   url="http://www.foo.com/movie.mov"
+     *   fileSize="12216320"
+     *   type="video/quicktime"
+     *   medium="video"
+     *   isDefault="true"
+     *   expression="full"
+     *   bitrate="128"
+     *   framerate="25"
+     *   samplingrate="44.1"
+     *   channels="2"
+     *   duration="185"
+     *   height="200"
+     *   width="300"
+     *   lang="en" />
+     *
+     * url should specify the direct URL to the media object. If not included, a <media:player> element must be specified.
+     *
+     * fileSize is the number of bytes of the media object. It is an optional attribute.
+     *
+     * type is the standard MIME type of the object. It is an optional attribute.
+     *
+     * medium is the type of object (image | audio | video | document | executable). While this attribute can at times seem redundant if type is supplied, it is included because it simplifies decision making on the reader side, as well as flushes out any ambiguities between MIME type and object type. It is an optional attribute.
+     *
+     * isDefault determines if this is the default object that should be used for the <media:group>. There should only be one default object per <media:group>. It is an optional attribute.
+     *
+     * expression determines if the object is a sample or the full version of the object, or even if it is a continuous stream (sample | full | nonstop). Default value is "full". It is an optional attribute.
+     *
+     * bitrate is the kilobits per second rate of media. It is an optional attribute.
+     *
+     * framerate is the number of frames per second for the media object. It is an optional attribute.
+     *
+     * samplingrate is the number of samples per second taken to create the media object. It is expressed in thousands of samples per second (kHz). It is an optional attribute.
+     *
+     * channels is number of audio channels in the media object. It is an optional attribute.
+     *
+     * duration is the number of seconds the media object plays. It is an optional attribute.
+     *
+     * height is the height of the media object. It is an optional attribute.
+     *
+     * width is the width of the media object. It is an optional attribute.
+     *
+     * lang is the primary language encapsulated in the media object. Language codes possible are detailed in RFC 3066. This attribute is used similar to the xml:lang attribute detailed in the XML 1.0 Specification (Third Edition). It is an optional attribute.
+     *
+     * These optional attributes, along with the optional elements below, contain the primary metadata entries needed to index and organize media content. Additional supported attributes for describing images, audio and video may be added in future revisions of this document.
+     *
+     * Note: While both <media:content> and <media:group> have no limitations on the number of times they can appear, the general nature of RSS should be preserved: an <item> represents a "story." Simply stated, this is similar to the blog style of syndication. However, if one is using this module to strictly publish media, there should be one <item> element for each media object/group. This is to allow for proper attribution for the origination of the media content through the <link> element. It also allows the full benefit of the other RSS elements to be realized.
+     */
+
+    public function testContentTag()
+    {
+        $xml = '
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Title of page</title>
+                    <link>http://www.foo.com</link>
+                    <description>Description of page</description>
+                    <item>
+                        <title>Story about something</title>
+                        <link>http://www.foo.com/item1.htm</link>
+                        <media:content
+                            url="http://www.foo.com/movie.mov"
+                            fileSize="2000"
+                            type="video/quicktime"
+                            medium="video"
+                            isDefault="true"
+                            expression="full"
+                            bitrate="128"
+                            framerate="25"
+                            samplingrate="44.1"
+                            channels="2"
+                            duration="185"
+                            height="200"
+                            width="300"
+                            lang="en"/>
+                    </item>
+                </channel>
+            </rss>';
+
+        $media = $this->getMediaFromXML($xml);
+
+        $this->assertEquals('http://www.foo.com/movie.mov', $media->getUrl());
+        $this->assertEquals(2000, $media->getContent()->getFileSize());
+        $this->assertEquals(128, $media->getContent()->getBitrate());
+        $this->assertEquals(25, $media->getContent()->getFramerate());
+        $this->assertEquals(44.1, $media->getContent()->getSamplingrate());
+        $this->assertEquals(185, $media->getContent()->getDuration());
+        $this->assertEquals(200, $media->getContent()->getHeight());
+        $this->assertEquals(300, $media->getContent()->getWidth());
+        $this->assertEquals('en', $media->getContent()->getLang());
+        $this->assertEquals('video/quicktime', $media->getType());
+        $this->assertEquals(MediaContentExpression::Full, $media->getContent()->getExpression());
+        $this->assertEquals(MediaContentMedium::Video, $media->getContent()->getMedium());
+        $this->assertTrue($media->getContent()->isDefault());
+    }
+
+    public function testContentTagDefaults()
+    {
+        $xml = '
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Title of page</title>
+                    <link>http://www.foo.com</link>
+                    <description>Description of page</description>
+                    <item>
+                        <title>Story about something</title>
+                        <link>http://www.foo.com/item1.htm</link>
+                        <media:content url="http://www.foo.com/movie.mov" />
+                    </item>
+                </channel>
+            </rss>';
+
+        $media = $this->getMediaFromXML($xml);
+
+        $this->assertEquals('http://www.foo.com/movie.mov', $media->getUrl());
+        $this->assertEquals(null, $media->getContent()->getFileSize());
+        $this->assertEquals(null, $media->getContent()->getBitrate());
+        $this->assertEquals(null, $media->getContent()->getFramerate());
+        $this->assertEquals(null, $media->getContent()->getSamplingrate());
+        $this->assertEquals(null, $media->getContent()->getDuration());
+        $this->assertEquals(null, $media->getContent()->getHeight());
+        $this->assertEquals(null, $media->getContent()->getWidth());
+        $this->assertEquals(null, $media->getContent()->getLang());
+        $this->assertEquals(null, $media->getType());
+        $this->assertEquals(null, $media->getContent()->getExpression());
+        $this->assertEquals(null, $media->getContent()->getMedium());
+        $this->assertTrue($media->getContent()->isDefault());
+    }
+
+    /**
+     * media:rating
+     *
+     * This allows the permissible audience to be declared. If this element is not included, it assumes that no restrictions are necessary. It has one optional attribute.
+     *
+     * <media:rating scheme="urn:simple">adult</media:rating>
+     * <media:rating scheme="urn:icra">r (cz 1 lz 1 nz 1 oz 1 vz 1)</media:rating>
+     * <media:rating scheme="urn:mpaa">pg</media:rating>
+     * <media:rating scheme="urn:v-chip">tv-y7-fv</media:rating>
+     *
+     * scheme is the URI that identifies the rating scheme. It is an optional attribute. If this attribute is not included, the default scheme is urn:simple (adult | nonadult).
+     */
+
+    public function testRatingTag()
+    {
+        $xml = '<media:rating scheme="urn:icra">r (cz 1 lz 1 nz 1 oz 1 vz 1)</media:rating>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("r (cz 1 lz 1 nz 1 oz 1 vz 1)", $media->getRating()->getContent());
+        $this->assertEquals('urn:icra', $media->getRating()->getScheme());
+    }
+
+    public function testRatingTagDefaults()
+    {
+        $xml = '<media:rating>adult</media:rating>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("adult", $media->getRating()->getContent());
+        $this->assertEquals('urn:simple', $media->getRating()->getScheme());
+    }
+
+    /**
+     * media:title
+     *
+     * The title of the particular media object. It has one optional attribute.
+     *
+     * <media:title type="plain">The Judy's -- The Moo Song</media:title>
+     *
+     * type specifies the type of text embedded. Possible values are either "plain" or "html". Default value is "plain". All HTML must be entity-encoded. It is an optional attribute.
+     */
+
+    public function testTitleTag()
+    {
+        $xml = '<media:title type="plain">The Judy\'s -- The Moo Song</media:title>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("The Judy's -- The Moo Song", $media->getTitle());
+        $this->assertEquals(MediaTitleType::Plain, $media->getTitleType());
+    }
+
+    public function testTitleTagDefaults()
+    {
+        $xml = '<media:title>The Judy\'s -- The Moo Song</media:title>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("The Judy's -- The Moo Song", $media->getTitle());
+        $this->assertEquals(MediaTitleType::Plain, $media->getTitleType());
+    }
+
+    /**
+     * media:description
+     *
+     * Short description describing the media object typically a sentence in length. It has one optional attribute.
+     *
+     * <media:description type="plain">This was some really bizarre band I listened to as a young lad.</media:description>
+     *
+     * type specifies the type of text embedded. Possible values are either "plain" or "html". Default value is "plain". All HTML must be entity-encoded. It is an optional attribute.
+     */
+
+    public function testDescriptionTag()
+    {
+        $xml = '<media:description type="plain">This was some really bizarre band I listened to as a young lad.</media:description>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("This was some really bizarre band I listened to as a young lad.", $media->getDescription());
+        $this->assertEquals(MediaDescriptionType::Plain, $media->getDescriptionType());
+    }
+
+    public function testDescriptionTagDefaults()
+    {
+        $xml = '<media:description>This was some really bizarre band I listened to as a young lad.</media:description>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("This was some really bizarre band I listened to as a young lad.", $media->getDescription());
+        $this->assertEquals(MediaDescriptionType::Plain, $media->getDescriptionType());
+    }
+
+    /**
+     * media:keywords
+     *
+     * Highly relevant keywords describing the media object with typically a maximum of 10 words. The keywords and phrases should be comma-delimited.
+     *
+     * <media:keywords>kitty, cat, big dog, yarn, fluffy</media:keywords>
+     */
+
+    public function testKeywordsTag()
+    {
+        $xml = '<media:keywords>kitty, cat, big dog, yarn, fluffy</media:keywords>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(["kitty", "cat", "big dog", "yarn", "fluffy"], $media->getKeywords());
+    }
+
+    /**
+     * media:thumbnail
+     *
+     * Allows particular images to be used as representative images for the media object. If multiple thumbnails are included, and time coding is not at play, it is assumed that the images are in order of importance. It has one required attribute and three optional attributes.
+     *
+     * <media:thumbnail url="http://www.foo.com/keyframe.jpg" width="75" height="50" time="12:05:01.123" />
+     *
+     * url specifies the url of the thumbnail. It is a required attribute.
+     *
+     * height specifies the height of the thumbnail. It is an optional attribute.
+     *
+     * width specifies the width of the thumbnail. It is an optional attribute.
+     *
+     * time specifies the time offset in relation to the media object. Typically this is used when creating multiple keyframes within a single video. The format for this attribute should be in the DSM-CC's Normal Play Time (NTP) as used in RTSP [RFC 2326 3.6 Normal Play Time]. It is an optional attribute.
+     *
+     * Notes:
+     *
+     * NTP has a second or subsecond resolution. It is specified as H:M:S.h (npt-hhmmss) or S.h (npt-sec), where H=hours, M=minutes, S=second and h=fractions of a second.
+     *
+     * A possible alternative to NTP would be SMPTE. It is believed that NTP is simpler and easier to use.
+     */
+
+    public function testThumbnailsTag()
+    {
+        $xml = '<media:thumbnail url="http://www.foo.com/keyframe.jpg" width="75" height="50" time="12:05:01.123" />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("http://www.foo.com/keyframe.jpg", $media->getThumbnail()->getUrl());
+        $this->assertEquals(75, $media->getThumbnail()->getWidth());
+        $this->assertEquals(50, $media->getThumbnail()->getHeight());
+        $this->assertEquals(new \DateTime("12:05:01.123"), $media->getThumbnail()->getTime());
+    }
+
+    public function testThumbnailsTagDefaults()
+    {
+        $xml = '<media:thumbnail url="http://www.foo.com/keyframe.jpg" />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("http://www.foo.com/keyframe.jpg", $media->getThumbnail()->getUrl());
+        $this->assertEquals(null, $media->getThumbnail()->getWidth());
+        $this->assertEquals(null, $media->getThumbnail()->getHeight());
+        $this->assertEquals(null, $media->getThumbnail()->getTime());
+    }
+
+    /**
+     * media:category
+     *
+     * Allows a taxonomy to be set that gives an indication of the type of media content, and its particular contents. It has two optional attributes.
+     *
+     * <media:category scheme="http://search.yahoo.com/mrss/category_schema">music/artist/album/song</media:category>
+     *
+     * <media:category scheme="http://dmoz.org" label="Ace Ventura - Pet Detective">Arts/Movies/Titles/A/Ace_Ventura_Series/Ace_Ventura_ -_Pet_Detective</media:category>
+     *
+     * <media:category scheme="urn:flickr:tags">ycantpark mobile</media:category>
+     *
+     * scheme is the URI that identifies the categorization scheme. It is an optional attribute. If this attribute is not included, the default scheme is "http://search.yahoo.com/mrss/category_schema".
+     *
+     * label is the human readable label that can be displayed in end user applications. It is an optional attribute.
+     */
+
+    public function testCategoryTag()
+    {
+        $xml = '<media:category scheme="http://dmoz.org" label="Ace Ventura - Pet Detective">Arts/Movies/Titles/A/Ace_Ventura_Series/Ace_Ventura_ -_Pet_Detective</media:category>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("Arts/Movies/Titles/A/Ace_Ventura_Series/Ace_Ventura_ -_Pet_Detective", $media->getCategory()->getText());
+        $this->assertEquals("Ace Ventura - Pet Detective", $media->getCategory()->getLabel());
+        $this->assertEquals("http://dmoz.org", $media->getCategory()->getScheme());
+    }
+
+    public function testCategoryTagDefaults()
+    {
+        $xml = '<media:category>foobar</media:category>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("foobar", $media->getCategory()->getText());
+        $this->assertEquals(null, $media->getCategory()->getLabel());
+        $this->assertEquals("http://search.yahoo.com/mrss/category_schema", $media->getCategory()->getScheme());
+    }
+
+    /**
+     * media:hash
+     *
+     * This is the hash of the binary media file. It can appear multiple times as long as each instance is a different algo. It has one optional attribute.
+     *
+     * <media:hash algo="md5">dfdec888b72151965a34b4b59031290a</media:hash>
+     *
+     * algo indicates the algorithm used to create the hash. Possible values are "md5" and "sha-1". Default value is "md5". It is an optional attribute.
+     */
+
+    public function testHashTag()
+    {
+        $xml = '<media:hash algo="SHA1">dfdec888b72151965a34b4b59031290a</media:hash>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("dfdec888b72151965a34b4b59031290a", $media->getHash()->getContent());
+        $this->assertEquals(MediaHashAlgo::SHA1, $media->getHash()->getAlgo());
+    }
+
+    public function testHashTagDefaults()
+    {
+        $xml = '<media:hash>dfdec888b72151965a34b4b59031290a</media:hash>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("dfdec888b72151965a34b4b59031290a", $media->getHash()->getContent());
+        $this->assertEquals(MediaHashAlgo::MD5, $media->getHash()->getAlgo());
+    }
+
+    /**
+     * media:player
+     *
+     * Allows the media object to be accessed through a web browser media player console. This element is required only if a direct media url attribute is not specified in the <media:content> element. It has one required attribute and two optional attributes.
+     *
+     * <media:player url="http://www.foo.com/player?id=1111" height="200" width="400" />
+     *
+     * url is the URL of the player console that plays the media. It is a required attribute.
+     *
+     * height is the height of the browser window that the URL should be opened in. It is an optional attribute.
+     *
+     * width is the width of the browser window that the URL should be opened in. It is an optional attribute.
+     */
+
+    public function testPlayerTag()
+    {
+        $xml = '<media:player url="http://www.foo.com/player?id=1111" height="200" width="400" />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals('http://www.foo.com/player?id=1111', $media->getPlayer()->getUrl());
+        $this->assertEquals(400, $media->getPlayer()->getWidth());
+        $this->assertEquals(200, $media->getPlayer()->getHeight());
+    }
+
+    public function testPlayerTagDefaults()
+    {
+        $xml = '<media:player url="http://www.foo.com/player?id=1111" />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals('http://www.foo.com/player?id=1111', $media->getPlayer()->getUrl());
+        $this->assertEquals(null, $media->getPlayer()->getWidth());
+        $this->assertEquals(null, $media->getPlayer()->getHeight());
+    }
+
+    /**
+     * media:credit
+     *
+     * Notable entity and the contribution to the creation of the media object. Current entities can include people, companies, locations, etc. Specific entities can have multiple roles, and several entities can have the same role. These should appear as distinct <media:credit> elements. It has two optional attributes.
+     *
+     * <media:credit role="producer" scheme="urn:ebu">entity name</media:credit>
+     *
+     * <media:credit role="owner" scheme="urn:yvs">copyright holder of the entity</media:credit>
+     *
+     * role specifies the role the entity played. Must be lowercase. It is an optional attribute.
+     *
+     * scheme is the URI that identifies the role scheme. It is an optional attribute and possible values for this attribute are ( urn:ebu | urn:yvs ) . The default scheme is "urn:ebu". The list of roles supported under urn:ebu scheme can be found at European Broadcasting Union Role Codes. The roles supported under urn:yvs scheme are ( uploader | owner ).
+     *
+     * Example roles:
+     *
+     *     actor
+     *     anchor person
+     *     author
+     *     choreographer
+     *     composer
+     *     conductor
+     *     director
+     *     editor
+     *     graphic designer
+     *     grip
+     *     illustrator
+     *     lyricist
+     *     music arranger
+     *     music group
+     *     musician
+     *     orchestra
+     *     performer
+     *     photographer
+     *     producer
+     *     reporter
+     *     vocalist
+     *
+     * Additional roles: European Broadcasting Union Role Codes.
+     */
+
+    public function testCreditTag()
+    {
+        $xml = '
+            <media:credit role="producer" scheme="urn:ebu">entity name</media:credit>
+            <media:credit role="owner" scheme="urn:yvs">copyright holder of the entity</media:credit>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        list($credit1, $credit2) = $media->getCredits();
+
+        $this->assertEquals(MediaCreditScheme::URN_EBU, $credit1->getScheme());
+        $this->assertEquals("producer", $credit1->getRole());
+        $this->assertEquals("entity name", $credit1->getValue());
+
+        $this->assertEquals(MediaCreditScheme::URN_YVS, $credit2->getScheme());
+        $this->assertEquals("owner", $credit2->getRole());
+        $this->assertEquals("copyright holder of the entity", $credit2->getValue());
+    }
+
+    public function testCreditTagDefaults()
+    {
+        $xml = '<media:credit>entity name</media:credit>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        list($credit) = $media->getCredits();
+
+        $this->assertEquals(MediaCreditScheme::URN_EBU, $credit->getScheme());
+        $this->assertEquals(null, $credit->getRole());
+        $this->assertEquals("entity name", $credit->getValue());
+    }
+
+    /**
+     * media:copyright
+     *
+     * Copyright information for the media object. It has one optional attribute.
+     *
+     * <media:copyright url="http://blah.com/additional-info.html">2005 FooBar Media</media:copyright>
+     *
+     * url is the URL for a terms of use page or additional copyright information. If the media is operating under a Creative Commons license, the Creative Commons module should be used instead. It is an optional attribute.
+     */
+
+    public function testCopyrightTag()
+    {
+        $xml = '<media:copyright url="http://blah.com/additional-info.html">2005 FooBar Media</media:copyright>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals('2005 FooBar Media', $media->getCopyright()->getContent());
+        $this->assertEquals('http://blah.com/additional-info.html', $media->getCopyright()->getUrl());
+    }
+
+    public function testCopyrightTagDefaults()
+    {
+        $xml = '<media:copyright>2005 FooBar Media</media:copyright>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals('2005 FooBar Media', $media->getCopyright()->getContent());
+        $this->assertEquals(null, $media->getCopyright()->getUrl());
+    }
+
+
+    /**
+     * media:text
+     *
+     * Allows the inclusion of a text transcript, closed captioning or lyrics of the media content. Many of these elements are permitted to provide a time series of text. In such cases, it is encouraged, but not required, that the elements be grouped by language and appear in time sequence order based on the start time. Elements can have overlapping start and end times. It has four optional attributes.
+     *
+     * <media:text type="plain" lang="en" start="00:00:03.000" end="00:00:10.000"> Oh, say, can you see</media:text>
+     *
+     * <media:text type="plain" lang="en" start="00:00:10.000" end="00:00:17.000">By the dawn's early light</media:text>
+     *
+     * type specifies the type of text embedded. Possible values are either "plain" or "html". Default value is "plain". All HTML must be entity-encoded. It is an optional attribute.
+     *
+     * lang is the primary language encapsulated in the media object. Language codes possible are detailed in RFC 3066. This attribute is used similar to the xml:lang attribute detailed in the XML 1.0 Specification (Third Edition). It is an optional attribute.
+     *
+     * start specifies the start time offset that the text starts being relevant to the media object. An example of this would be for closed captioning. It uses the NTP time code format (see: the time attribute used in <media:thumbnail>). It is an optional attribute.
+     *
+     * end specifies the end time that the text is relevant. If this attribute is not provided, and a start time is used, it is expected that the end time is either the end of the clip or the start of the next <media:text> element.
+     */
+
+    public function testTextTag()
+    {
+        $xml = '
+            <media:text type="plain" lang="en" start="00:00:03.000" end="00:00:10.000">Oh, say, can you see</media:text>
+            <media:text type="html" lang="en" start="00:00:10.000" end="00:00:17.000">By the dawn\'s early light</media:text>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        list($text1, $text2) = $media->getTexts();
+        $this->assertEquals('Oh, say, can you see', $text1->getValue());
+        $this->assertEquals(MediaTextType::Plain, $text1->getType());
+        $this->assertEquals("en", $text1->getLang());
+        $this->assertEquals(new \DateTime("00:00:03.000"), $text1->getStart());
+        $this->assertEquals(new \DateTime("00:00:10.000"), $text1->getEnd());
+
+        $this->assertEquals(MediaTextType::HTML, $text2->getType());
+    }
+
+    public function testTextTagDefaults()
+    {
+        $xml = '<media:text>Oh, say, can you see</media:text>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        list($text1) = $media->getTexts();
+        $this->assertEquals('Oh, say, can you see', $text1->getValue());
+        $this->assertEquals(MediaTextType::Plain, $text1->getType());
+        $this->assertEquals(null, $text1->getLang());
+        $this->assertEquals(null, $text1->getStart());
+        $this->assertEquals(null, $text1->getEnd());
+    }
+
+    /**
+     * media:restriction
+     *
+     * Allows restrictions to be placed on the aggregator rendering the media in the feed. Currently, restrictions are based on distributor (URI), country codes and sharing of a media object. This element is purely informational and no obligation can be assumed or implied. Only one <media:restriction> element of the same type can be applied to a media object -- all others will be ignored. Entities in this element should be space-separated. To allow the producer to explicitly declare his/her intentions, two literals are reserved: "all", "none". These literals can only be used once. This element has one required attribute and one optional attribute (with strict requirements for its exclusion).
+     *
+     * <media:restriction relationship="allow" type="country">au us</media:restriction>
+     *
+     * relationship indicates the type of relationship that the restriction represents (allow | deny). In the example above, the media object should only be syndicated in Australia and the United States. It is a required attribute.
+     *
+     * Note: If the "allow" element is empty and the type of relationship is "allow", it is assumed that the empty list means "allow nobody" and the media should not be syndicated.
+     *
+     * A more explicit method would be:
+     *
+     * <media:restriction relationship="allow" type="country">au us</media:restriction>
+     *
+     * type specifies the type of restriction (country | uri | sharing ) that the media can be syndicated. It is an optional attribute; however can only be excluded when using one of the literal values "all" or "none".
+     *
+     * "country" allows restrictions to be placed based on country code. [ISO 3166]
+     *
+     * "uri" allows restrictions based on URI. Examples: urn:apple, http://images.google.com, urn:yahoo, etc.
+     *
+     * "sharing" allows restriction on sharing.
+     *
+     * "deny" means content cannot be shared -- for example via embed tags. If the sharing type is not present, the default functionality is to allow sharing. For example:
+     *
+     * <media:restriction type="sharing" relationship="deny" />
+     */
+
+    public function testRestrictionTag()
+    {
+        $xml = '<media:restriction relationship="allow" type="country">au us</media:restriction>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("au us", $media->getRestriction()->getContent());
+        $this->assertEquals(MediaRestrictionRelationship::Allow, $media->getRestriction()->getRelationship());
+        $this->assertEquals(MediaRestrictionType::Country, $media->getRestriction()->getType());
+    }
+
+    public function testRestrictionTagDefaults()
+    {
+        $xml = '<media:restriction relationship="allow">all</media:restriction>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("all", $media->getRestriction()->getContent());
+        $this->assertEquals(MediaRestrictionRelationship::Allow, $media->getRestriction()->getRelationship());
+        $this->assertEquals(MediaRestrictionType::Sharing, $media->getRestriction()->getType());
+    }
+
+    /**
+     * media:community
+     *
+     * This element stands for the community related content. This allows inclusion of the user perception about a media object in the form of view count, ratings and tags.
+     *
+     * <media:community>
+     *   <media:starRating average="3.5" count="20" min="1" max="10" />
+     *   <media:statistics views="5" favorites="5" />
+     *   <media:tags>news: 5, abc:3, reuters</media:tags>
+     * </media:community>
+     *
+     * starRating This element specifies the rating-related information about a media object. Valid attributes are average, count, min and max.
+     *
+     * statistics This element specifies various statistics about a media object like the view count and the favorite count. Valid attributes are views and favorites.
+     *
+     * tags This element contains user-generated tags separated by commas in the decreasing order of each tag's weight. Each tag can be assigned an integer weight in tag_name:weight format. It's up to the provider to choose the way weight is determined for a tag; for example, number of occurences can be one way to decide weight of a particular tag. Default weight is 1.
+     */
+
+    public function testCommunityTag()
+    {
+        $xml = '
+            <media:community>
+                <media:starRating average="3.5" count="20" min="1" max="10" />
+                <media:statistics views="5" favorites="5" />
+                <media:tags>news: 5, abc:3</media:tags>
+            </media:community>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(3.5, $media->getCommunity()->getStarRatingAverage());
+        $this->assertEquals(20, $media->getCommunity()->getStarRatingCount());
+        $this->assertEquals(1, $media->getCommunity()->getStarRatingMin());
+        $this->assertEquals(10, $media->getCommunity()->getStarRatingMax());
+        $this->assertEquals(5, $media->getCommunity()->getNbViews());
+        $this->assertEquals(5, $media->getCommunity()->getNbFavorites());
+        $this->assertEquals(array('news' => 5, 'abc' => 3), $media->getCommunity()->getTags());
+    }
+
+    public function testCommunityTagDefaults()
+    {
+        $xml = '<media:community />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(null, $media->getCommunity()->getStarRatingAverage());
+        $this->assertEquals(null, $media->getCommunity()->getStarRatingCount());
+        $this->assertEquals(null, $media->getCommunity()->getStarRatingMin());
+        $this->assertEquals(null, $media->getCommunity()->getStarRatingMax());
+        $this->assertEquals(null, $media->getCommunity()->getNbViews());
+        $this->assertEquals(null, $media->getCommunity()->getNbFavorites());
+        $this->assertEquals(array(), $media->getCommunity()->getTags());
+    }
+
+    /**
+     * media:comments
+     *
+     * Allows inclusion of all the comments a media object has received.
+     *
+     * <media:comments>
+     *   <media:comment>comment1</media:comment>
+     *   <media:comment>comment2</media:comment>
+     *   <media:comment>comment3</media:comment>
+     * </media:comments>
+     */
+
+    public function testCommentsTag()
+    {
+        $xml = '
+            <media:comments>
+                <media:comment>comment1</media:comment>
+                <media:comment>comment2</media:comment>
+            </media:comments>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(array("comment1", "comment2"), $media->getComments());
+    }
+
+    public function testCommentsTagDefaults()
+    {
+        $xml = '<media:comments />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(array(), $media->getComments());
+    }
+
+    /**
+     * media:embed
+     *
+     * Sometimes player-specific embed code is needed for a player to play any video. <media:embed> allows inclusion of such information in the form of key-value pairs.
+     *
+     * <media:embed url="http://d.yimg.com/static.video.yahoo.com/yep/YV_YEP.swf?ver=2.2.2" width="512" height="323">
+     *   <media:param name="type">application/x-shockwave-flash</media:param>
+     *   <media:param name="width">512</media:param>
+     *   <media:param name="height">323</media:param>
+     *   <media:param name="allowFullScreen">true</media:param>
+     *   <media:param name="flashVars">
+     *     id=7809705&amp;vid=2666306&amp;lang=en-us&amp;intl=us&amp;thumbUrl=http%3A//us.i1.yimg.com/us.yimg.com/i/us/sch/cn/video06/2666306_rndf1e4205b_19.jpg
+     *   </media:param>
+     * </media:embed>
+     */
+
+    public function testEmbedTag()
+    {
+        $xml = '
+            <media:embed url="http://www.foo.com/player.swf" width="512" height="323">
+                <media:param name="type">application/x-shockwave-flash</media:param>
+                <media:param name="width">512</media:param>
+                <media:param name="height">323</media:param>
+                <media:param name="allowFullScreen">true</media:param>
+                <media:param name="flashVars">
+                    id=12345&amp;vid=678912i&amp;lang=en-us&amp;intl=us&amp;thumbUrl=http://www.foo.com/thumbnail.jpg
+                </media:param>
+            </media:embed>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals('http://www.foo.com/player.swf', $media->getEmbed()->getUrl());
+        $this->assertEquals(512, $media->getEmbed()->getWidth());
+        $this->assertEquals(323, $media->getEmbed()->getHeight());
+        $this->assertEquals(array(
+            "width" => "512",
+            "height" => "323",
+            "type" => "application/x-shockwave-flash",
+            "allowFullScreen" => "true",
+            "flashVars" => "id=12345&vid=678912i&lang=en-us&intl=us&thumbUrl=http://www.foo.com/thumbnail.jpg",
+        ), $media->getEmbed()->getParams());
+    }
+
+    public function testEmbedTagDefaults()
+    {
+        $xml = '<media:embed url="http://www.foo.com/player.swf" />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals('http://www.foo.com/player.swf', $media->getEmbed()->getUrl());
+        $this->assertEquals(null, $media->getEmbed()->getWidth());
+        $this->assertEquals(null, $media->getEmbed()->getHeight());
+        $this->assertEquals(array(), $media->getEmbed()->getParams());
+    }
+
+    /**
+     * media:response
+     *
+     * Allows inclusion of a list of all media responses a media object has received.
+     *
+     * <media:responses>
+     *   <media:response>response1</media:response>
+     *   <media:response>response2</media:response>
+     *   <media:response>response3</media:response>
+     * </media:responses>
+     */
+
+    public function testResponsesTag()
+    {
+        $xml = '
+            <media:responses>
+                <media:response>http://www.response1.com</media:response>
+                <media:response>http://www.response2.com</media:response>
+            </media:responses>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(array('http://www.response1.com', 'http://www.response2.com'), $media->getResponses());
+    }
+
+    public function testResponsesTagDefaults()
+    {
+        $xml = '<media:responses/>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(array(), $media->getResponses());
+    }
+
+    /**
+     * media:backlink
+     *
+     * Allows inclusion of all the URLs pointing to a media object.
+     *
+     * <media:backLinks>
+     *   <media:backLink>http://www.backlink1.com</media:backLink>
+     *   <media:backLink>http://www.backlink2.com</media:backLink>
+     *   <media:backLink>http://www.backlink3.com</media:backLink>
+     * </media:backLinks>
+     */
+
+    public function testBackLinksTag()
+    {
+        $xml = '
+            <media:backLinks>
+                <media:backLink>http://www.backlink1.com</media:backLink>
+                <media:backLink>http://www.backlink2.com</media:backLink>
+            </media:backLinks>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(array('http://www.backlink1.com', 'http://www.backlink2.com'), $media->getBacklinks());
+    }
+
+    public function testBackLinksTagDefaults()
+    {
+        $xml = '<media:backLinks/>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(array(), $media->getBacklinks());
+    }
+
+    /**
+     * media:status
+     *
+     * Optional tag to specify the status of a media object -- whether it's still active or it has been blocked/deleted.
+     *
+     * <media:status state="blocked" reason="http://www.reasonforblocking.com" />
+     *
+     * state can have values "active", "blocked" or "deleted". "active" means a media object is active in the system, "blocked" means a media object is blocked by the publisher, "deleted" means a media object has been deleted by the publisher.
+     *
+     * reason is a reason explaining why a media object has been blocked/deleted. It can be plain text or a URL.
+     */
+
+    public function testStatusTag()
+    {
+        $xml = '<media:status state="blocked" reason="http://www.reasonforblocking.com" />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(MediaStatusValue::Blocked, $media->getStatus()->getValue());
+        $this->assertEquals("http://www.reasonforblocking.com", $media->getStatus()->getReason());
+    }
+
+    public function testStatusTagDefaults()
+    {
+        $xml = '<media:status state="active"/>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(MediaStatusValue::Active, $media->getStatus()->getValue());
+        $this->assertEquals(null, $media->getStatus()->getReason());
+    }
+
+    /**
+     * media:price
+     *
+     * Optional tag to include pricing information about a media object. If this tag is not present, the media object is supposed to be free. One media object can have multiple instances of this tag for including different pricing structures. The presence of this tag would mean that media object is not free.
+     *
+     * <media:price type="rent" price="19.99" currency="EUR" />
+     *
+     * <media:price type="package" info="http://www.dummy.jp/package_info.html" price="19.99" currency="EUR" />
+     *
+     * <media:price type="subscription" info="http://www.dummy.jp/subscription_info" price="19.99" currency="EUR" />
+     *
+     * type Valid values are "rent", "purchase", "package" or "subscription". If nothing is specified, then the media is free.
+     *
+     * info if the type is "package" or "subscription", then info is a URL pointing to package or subscription information. This is an optional attribute.
+     *
+     * price is the price of the media object. This is an optional attribute.
+     *
+     * currency -- use [ISO 4217] for currency codes. This is an optional attribute.
+     */
+
+    public function testPriceTag()
+    {
+        $xml = '
+            <media:price type="rent" price="19.99" currency="EUR" />
+            <media:price type="rent" price="19.99" currency="USD" />
+        ';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        list($price1, $price2) = $media->getPrices();
+
+        $this->assertEquals(MediaPriceType::Rent, $price1->getType());
+        $this->assertEquals(19.99, $price1->getValue());
+        $this->assertEquals('EUR', $price1->getCurrency());
+    }
+
+    public function testPriceTagDefaults()
+    {
+        $xml = '<media:price />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        list($price) = $media->getPrices();
+
+        $this->assertEquals(null, $price->getType());
+        $this->assertEquals(null, $price->getValue());
+        $this->assertEquals(null, $price->getCurrency());
+    }
+
+    /**
+     * media:license
+     *
+     * Optional link to specify the machine-readable license associated with the content.
+     *
+     * <media:license type="text/html" href="http://creativecommons.org/licenses/by/3.0/us/">Creative Commons Attribution 3.0 United States License</media:license>
+     */
+
+    public function testLicenseTag()
+    {
+        $xml = '<media:license type="text/html" href="http://www.licensehost.com/license">Sample license for a video</media:license>';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals("Sample license for a video", $media->getLicense()->getContent());
+        $this->assertEquals("http://www.licensehost.com/license", $media->getLicense()->getUrl());
+        $this->assertEquals("text/html", $media->getLicense()->getType());
+    }
+
+    /**
+     * media:subtitle
+     *
+     * Optional element for subtitle/CC link. It contains type and language attributes. Language is based on RFC 3066. There can be more than one such tag per media element, for example one per language. Please refer to Timed Text spec - W3C for more information on Timed Text and Real Time Subtitling.
+     *
+     * <media:subTitle type="application/smil" lang="en-us" href="http://www.example.org/subtitle.smil" />
+     */
+
+    public function testSubTitleTag()
+    {
+        $xml = '
+            <media:subTitle type="application/smil" lang="en-us" href="http://www.foo.org/en/subtitle.smil" />
+            <media:subTitle type="application/smil" lang="fr-fr" href="http://www.foo.org/fr/subtitle.smil" />
+        ';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        list($subtitle1, $subtitle2) = $media->getSubtitles();
+
+        $this->assertEquals("application/smil", $subtitle1->getType());
+        $this->assertEquals("en-us", $subtitle1->getLang());
+        $this->assertEquals("http://www.foo.org/en/subtitle.smil", $subtitle1->getUrl());
+
+        $this->assertEquals("application/smil", $subtitle2->getType());
+        $this->assertEquals("fr-fr", $subtitle2->getLang());
+        $this->assertEquals("http://www.foo.org/fr/subtitle.smil", $subtitle2->getUrl());
+    }
+
+    /**
+     * media:peerlink
+     *
+     * Optional element for P2P link.
+     *
+     * <media:peerLink type="application/x-bittorrent" href="http://www.example.org/sampleFile.torrent" />
+     *
+     */
+
+    public function testPeerLinkTag()
+    {
+        $xml = '<media:peerLink type="application/x-bittorrent" href="http://www.foo.org/sampleFile.torrent" />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals('http://www.foo.org/sampleFile.torrent', $media->getPeerLink()->getUrl());
+        $this->assertEquals('application/x-bittorrent', $media->getPeerLink()->getType());
+    }
+
+    /**
+     * media:rights
+     *
+     * Optional element to specify the rights information of a media object.
+     *
+     * <media:rights status="userCreated" />
+     *
+     * <media:rights status="official" />
+     *
+     * status is the status of the media object saying whether a media object has been created by the publisher or they have rights to circulate it. Supported values are "userCreated" and "official".
+     */
+    public function testRightsTag()
+    {
+        $xml = '<media:rights status="official" />';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        $this->assertEquals(MediaRightsStatus::Official, $media->getRights());
+    }
+
+    /**
+     * media:scene
+     *
+     * Optional element to specify various scenes within a media object. It can have multiple child <media:scene> elements, where each <media:scene> element contains information about a particular scene. <media:scene> has the optional sub-elements <sceneTitle>, <sceneDescription>, <sceneStartTime> and <sceneEndTime>, which contains title, description, start and end time of a particular scene in the media, respectively.
+     *
+     * <media:scenes>
+     *   <media:scene>
+     *     <sceneTitle>sceneTitle1</sceneTitle>
+     *     <sceneDescription>sceneDesc1</sceneDescription>
+     *     <sceneStartTime>00:15</sceneStartTime>
+     *     <sceneEndTime>00:45</sceneEndTime>
+     *   </media:scene>
+     *   <media:scene>
+     *     <sceneTitle>sceneTitle2</sceneTitle>
+     *     <sceneDescription>sceneDesc2</sceneDescription>
+     *     <sceneStartTime>00:57</sceneStartTime>
+     *     <sceneEndTime>01:45</sceneEndTime>
+     *     </media:scene>
+     * </media:scenes>
+     */
+    public function testScenesTag()
+    {
+        $xml = '
+             <media:scenes>
+                 <media:scene>
+                     <sceneTitle>sceneTitle1</sceneTitle>
+                     <sceneDescription>sceneDesc1</sceneDescription>
+                     <sceneStartTime>00:15</sceneStartTime>
+                     <sceneEndTime>00:45</sceneEndTime>
+                 </media:scene>
+                 <media:scene>
+                     <sceneTitle>sceneTitle2</sceneTitle>
+                     <sceneDescription>sceneDesc2</sceneDescription>
+                     <sceneStartTime>00:57</sceneStartTime>
+                     <sceneEndTime>01:45</sceneEndTime>
+                 </media:scene>
+             </media:scenes>
+        ';
+        $media = $this->getMediaFromXMLSample($xml);
+
+        list($scene1, $scene2) = $media->getScenes();
+
+        $this->assertEquals("sceneTitle1", $scene1->getTitle());
+        $this->assertEquals("sceneDesc1", $scene1->getDescription());
+        $this->assertEquals(new \DateTime("00:15"), $scene1->getStartTime());
+        $this->assertEquals(new \DateTime("00:45"), $scene1->getEndTime());
+
+        $this->assertEquals("sceneTitle2", $scene2->getTitle());
+        $this->assertEquals("sceneDesc2", $scene2->getDescription());
+        $this->assertEquals(new \DateTime("00:57"), $scene2->getStartTime());
+        $this->assertEquals(new \DateTime("01:45"), $scene2->getEndTime());
     }
 }

--- a/tests/FeedIo/Parser/MediaRSSTest.php
+++ b/tests/FeedIo/Parser/MediaRSSTest.php
@@ -15,56 +15,64 @@ use FeedIo\Parser\XmlParser as Parser;
 use FeedIo\Reader\Document;
 use FeedIo\Rule\DateTimeBuilder;
 use FeedIo\Standard\Atom;
+use FeedIo\Standard\Rss;
 use Psr\Log\NullLogger;
 
 use \PHPUnit\Framework\TestCase;
 
 class MediaRssTest extends TestCase
 {
-    const SAMPLE_FILE = 'rss/sample-youtube.xml';
-
-    /**
-     * @return \FeedIo\StandardAbstract
-     */
-    public function getStandard()
-    {
-        return new Atom(new DateTimeBuilder());
-    }
-
-    public function setUp(): void
-    {
-        $standard = $this->getStandard();
-        $this->object = new Parser($standard, new NullLogger());
-    }
+    const YOUTUBE_SAMPLE_FILE = 'rss/sample-youtube.xml';
 
     /**
      * @param $filename
      * @return Document
      */
-    protected function buildDomDocument($filename)
+    protected function getMediaFromFile($filename, $nb=1)
     {
         $file = dirname(__FILE__)."/../../samples/{$filename}";
         $domDocument = new \DOMDocument();
         $domDocument->load($file, LIBXML_NOBLANKS | LIBXML_COMPACT);
 
-        return new Document($domDocument->saveXML());
+        $document = new Document($domDocument->saveXML());
+        $standard = new Atom(new DateTimeBuilder());
+        $parser = new Parser($standard, new NullLogger());
+        $feed = $parser->parse($document, new Feed());
+
+        return $this->getMediaFromFeed($feed, $nb);
+    }
+
+    protected function getMediaFromXML($xml, $nb=1)
+    {
+        $document = new Document($xml);
+        $standard = new Rss(new DateTimeBuilder());
+        $parser = new Parser($standard, new NullLogger());
+        $feed = $parser->parse($document, new Feed());
+        return $this->getMediaFromFeed($feed, $nb);
+    }
+
+    protected function getMediaFromFeed($feed, $nb=1)
+    {
+        $this->assertEquals(1, count($feed));
+        $item = $feed->current();
+
+        $this->assertTrue($item->hasMedia());
+        $this->assertEquals($nb, count($item->getMedias()));
+        if ($nb > 1) {
+            return $item->getMedias();
+        }
+
+        $media = $item->getMedias()->current();
+        $this->assertInstanceOf('\FeedIo\Feed\Item\MediaInterface', $media);
+        return $media;
     }
 
     public function testYoutubeFeed()
     {
-        $document = $this->buildDomDocument(static::SAMPLE_FILE);
-        $feed = $this->object->parse($document, new Feed());
-
-        $this->assertEquals(1, count($feed));
-        foreach ($feed as $item) {
-            $this->assertTrue($item->hasMedia());
-            $media = $item->getMedias()->current();
-
-            $this->assertInstanceOf('\FeedIo\Feed\Item\MediaInterface', $media);
-            $this->assertEquals('YT_VIDEO_TITLE', $media->getTitle());
-            $this->assertEquals('https://i2.ytimg.com/vi/YT_VIDEO_ID/hqdefault.jpg', $media->getThumbnail());
-            $this->assertEquals("This is a\nmultiline\ndescription", $media->getDescription());
-            $this->assertEquals('https://www.youtube.com/v/YT_VIDEO_ID?version=3', $media->getUrl());
-        }
+        $media = $this->getMediaFromFile(static::YOUTUBE_SAMPLE_FILE);
+        $this->assertEquals('YT_VIDEO_TITLE', $media->getTitle());
+        $this->assertEquals('https://i2.ytimg.com/vi/YT_VIDEO_ID/hqdefault.jpg', $media->getThumbnail());
+        $this->assertEquals("This is a\nmultiline\ndescription", $media->getDescription());
+        $this->assertEquals('https://www.youtube.com/v/YT_VIDEO_ID?version=3', $media->getUrl());
     }
 }


### PR DESCRIPTION
This PR attempts to fix #240 
Let me know if there are things I need to change!

Éloi

# Commits review

### MRSS-1
This commit is just some test refactoring. It is mostly harmless

### MRSS-2
This commit follows #252 and remove the deprecated method

### MRSS-3
This commit implements the priority mechanism explained in the [specification](http://www.rssboard.org/media-rss#optional-elements):

> The following elements are optional and may appear as sub-elements of &lt;channel>, &lt;item>, &lt;media:content> and/or &lt;media:group>.
>
> When an element appears at a shallow level, such as <channel> or <item>, it means that the element should be applied to every media object within its scope.
> 
> Duplicated elements appearing at deeper levels of the document tree have higher priority over other levels. For example, &lt;media:content> level elements are favored over &lt;item> level elements. The priority level is listed from strongest to weakest: &lt;media:content>, &lt;media:group>, &lt;item>, &lt;channel>.

You might want to have a look at the `findTags` method in `Rule/Media.php` that implements this mechanism with XPath. I tried to minimize their use at the maximum but there should be at least ~20 XPath use by feed.

### MRSS-4
This one is the big one. It adds all the tags and attributes the specification details.

For each tag I copy/pasted matching piece of specification in the test comments, and tried to implement what I understood. I made some design choices you may have an advice on:

- in `item/Media.php` I created some `enum` classes (like `abstract class MediaContentMedium`) for attributes that can only have certain values (for instance, `<media:content medium>` attribute can only has those values `image`, `audio`, `video`, `document` or `executable`);
- I also implemented some shallow classes (like `MediaCredit`) in some cases, where maybe arrays should have sufficed.

### MRSS-5
A readme update