### PR TITLE
Read last modified value from response

### DIFF
--- a/src/FeedIo/FeedIo.php
+++ b/src/FeedIo/FeedIo.php
@@ -232,6 +232,7 @@ class FeedIo
     public function getBaseFixers() : array
     {
         return array(
+            new Reader\Fixer\HttpLastModified(),
             new Reader\Fixer\LastModified(),
             new Reader\Fixer\PublicId(),
         );
@@ -320,7 +321,7 @@ class FeedIo
         $this->logAction($feed, "read access : $url into a feed instance");
         $result = $this->reader->read($url, $feed, $modifiedSince);
 
-        $this->fixerSet->correct($result->getFeed());
+        $this->fixerSet->correct($result);
 
         return $result;
     }

--- a/src/FeedIo/Reader/Fixer/HttpLastModified.php
+++ b/src/FeedIo/Reader/Fixer/HttpLastModified.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Reader\Fixer;
+
+use FeedIo\Reader\FixerAbstract;
+use FeedIo\Reader\Result;
+
+class HttpLastModified extends FixerAbstract
+{
+
+    /**
+     * @param Result $result
+     * @return FixerAbstract
+     */
+    public function correct(Result $result): FixerAbstract
+    {
+        $feed = $result->getFeed();
+        $response = $result->getResponse();
+
+        if ($response->getLastModified() instanceof \DateTime) {
+            $this->logger->debug("found last modified: " . $response->getLastModified()->format(\DateTime::RSS));
+            $feed->setLastModified($response->getLastModified());
+        }
+
+        return $this;
+    }
+}

--- a/src/FeedIo/Reader/Fixer/HttpLastModified.php
+++ b/src/FeedIo/Reader/Fixer/HttpLastModified.php
@@ -25,7 +25,7 @@ class HttpLastModified extends FixerAbstract
         $feed = $result->getFeed();
         $response = $result->getResponse();
 
-        if ($response->getLastModified() instanceof \DateTime) {
+        if ($feed->getLastModified() === null && $response->getLastModified() instanceof \DateTime) {
             $this->logger->debug("found last modified: " . $response->getLastModified()->format(\DateTime::RSS));
             $feed->setLastModified($response->getLastModified());
         }

--- a/src/FeedIo/Reader/Fixer/LastModified.php
+++ b/src/FeedIo/Reader/Fixer/LastModified.php
@@ -12,17 +12,20 @@ namespace FeedIo\Reader\Fixer;
 
 use FeedIo\FeedInterface;
 use FeedIo\Reader\FixerAbstract;
+use FeedIo\Reader\Result;
 
 class LastModified extends FixerAbstract
 {
 
     /**
-     * @param  FeedInterface $feed
+     * @param Result $result
      * @return FixerAbstract
      */
-    public function correct(FeedInterface $feed) : FixerAbstract
+    public function correct(Result $result) : FixerAbstract
     {
+        $feed = $result->getFeed();
         $date = new \DateTime('@0');
+
         if (is_null($feed->getLastModified()) || $feed->getLastModified() == $date) {
             $this->logger->notice("correct last modified date for feed {$feed->getTitle()}");
             $feed->setLastModified(

--- a/src/FeedIo/Reader/Fixer/PublicId.php
+++ b/src/FeedIo/Reader/Fixer/PublicId.php
@@ -13,18 +13,20 @@ namespace FeedIo\Reader\Fixer;
 use FeedIo\FeedInterface;
 use FeedIo\Feed\NodeInterface;
 use FeedIo\Reader\FixerAbstract;
+use FeedIo\Reader\Result;
 
 class PublicId extends FixerAbstract
 {
 
     /**
-     * @param  FeedInterface $feed
+     * @param  Result $result
      * @return $this
      */
-    public function correct(FeedInterface $feed) : FixerAbstract
+    public function correct(Result $result) : FixerAbstract
     {
-        $this->fixNode($feed);
+        $feed = $result->getFeed();
 
+        $this->fixNode($feed);
         $this->fixItems($feed);
 
         return $this;

--- a/src/FeedIo/Reader/FixerAbstract.php
+++ b/src/FeedIo/Reader/FixerAbstract.php
@@ -33,8 +33,8 @@ abstract class FixerAbstract
     }
 
     /**
-     * @param FeedInterface $feed
+     * @param Result $result
      * @return FixerAbstract
      */
-    abstract public function correct(FeedInterface $feed) : FixerAbstract;
+    abstract public function correct(Result $result) : FixerAbstract;
 }

--- a/src/FeedIo/Reader/FixerSet.php
+++ b/src/FeedIo/Reader/FixerSet.php
@@ -28,13 +28,13 @@ class FixerSet
     }
 
     /**
-     * @param  FeedInterface $feed
+     * @param  Result $result
      * @return FixerSet
      */
-    public function correct(FeedInterface $feed) : FixerSet
+    public function correct(Result $result) : FixerSet
     {
         foreach ($this->fixers as $fixer) {
-            $fixer->correct($feed);
+            $fixer->correct($result);
         }
 
         return $this;

--- a/tests/FeedIo/Reader/Fixer/HttpLastModifiedTest.php
+++ b/tests/FeedIo/Reader/Fixer/HttpLastModifiedTest.php
@@ -44,6 +44,18 @@ class HttpLastModifiedTest extends TestCase
         $this->assertEquals(new \DateTime('@0'), $feed->getLastModified());
     }
 
+    public function testSkipCorrectIfLastModifiedNotNull()
+    {
+        $result = $this->getResultMock();
+        $feed = $result->getFeed();
+        $feed->setLastModified(new \DateTime('@3'));
+
+        $this->assertNotNull($feed->getLastModified());
+        $this->object->correct($result);
+
+        $this->assertEquals(new \DateTime('@3'), $feed->getLastModified());
+    }
+
     protected function getResultMock(): Result
     {
         /** @var Document $document */

--- a/tests/FeedIo/Reader/Fixer/HttpLastModifiedTest.php
+++ b/tests/FeedIo/Reader/Fixer/HttpLastModifiedTest.php
@@ -13,42 +13,24 @@ namespace FeedIo\Reader\Fixer;
 use FeedIo\Adapter\NullResponse;
 use FeedIo\Adapter\ResponseInterface;
 use FeedIo\Feed;
-use FeedIo\Feed\Item;
 use FeedIo\Reader\Document;
 use FeedIo\Reader\Result;
 use Psr\Log\NullLogger;
 
 use \PHPUnit\Framework\TestCase;
 
-class LastModifiedTest extends TestCase
+class HttpLastModifiedTest extends TestCase
 {
 
     /**
-     * @var LastModified
+     * @var HttpLastModified
      */
     protected $object;
 
-    /**
-     * @var \DateTime
-     */
-    protected $newest;
-
     protected function setUp()
     {
-        $this->newest = new \DateTime('2014-01-01');
-
-        $this->object = new LastModified();
+        $this->object = new HttpLastModified();
         $this->object->setLogger(new NullLogger());
-    }
-
-    public function testSearchLastModified()
-    {
-        $feed = $this->getFeed();
-
-        $this->assertEquals(
-            $this->newest,
-            $this->object->searchLastModified($feed)
-        );
     }
 
     public function testCorrect()
@@ -59,21 +41,7 @@ class LastModifiedTest extends TestCase
         $this->assertNull($feed->getLastModified());
         $this->object->correct($result);
 
-        $this->assertEquals($this->newest, $feed->getLastModified());
-    }
-
-    protected function getFeed()
-    {
-        $item1 = new Item();
-        $item1->setLastModified($this->newest);
-
-        $item2 = new Item();
-        $item2->setLastModified(new \DateTime('2013-01-01'));
-
-        $feed = new Feed();
-        $feed->add($item1)->add($item2);
-
-        return $feed;
+        $this->assertEquals(new \DateTime('@0'), $feed->getLastModified());
     }
 
     protected function getResultMock(): Result
@@ -81,7 +49,7 @@ class LastModifiedTest extends TestCase
         /** @var Document $document */
         $document = $this->createMock(Document::class);
         /** @var Feed $feed */
-        $feed = $this->getFeed();
+        $feed = new Feed();
         /** @var ResponseInterface $response */
         $response = new NullResponse();
 

--- a/tests/FeedIo/Reader/Fixer/HttpLastModifiedTest.php
+++ b/tests/FeedIo/Reader/Fixer/HttpLastModifiedTest.php
@@ -10,11 +10,7 @@
 
 namespace FeedIo\Reader\Fixer;
 
-use FeedIo\Adapter\NullResponse;
-use FeedIo\Adapter\ResponseInterface;
-use FeedIo\Feed;
-use FeedIo\Reader\Document;
-use FeedIo\Reader\Result;
+use FeedIo\Reader\ResultMockFactory;
 use Psr\Log\NullLogger;
 
 use \PHPUnit\Framework\TestCase;
@@ -27,15 +23,21 @@ class HttpLastModifiedTest extends TestCase
      */
     protected $object;
 
+    /**
+     * @var ResultMockFactory
+     */
+    protected $resultMockFactory;
+
     protected function setUp()
     {
         $this->object = new HttpLastModified();
         $this->object->setLogger(new NullLogger());
+        $this->resultMockFactory = new ResultMockFactory();
     }
 
     public function testCorrect()
     {
-        $result = $this->getResultMock();
+        $result = $this->resultMockFactory->make();
         $feed = $result->getFeed();
 
         $this->assertNull($feed->getLastModified());
@@ -46,7 +48,7 @@ class HttpLastModifiedTest extends TestCase
 
     public function testSkipCorrectIfLastModifiedNotNull()
     {
-        $result = $this->getResultMock();
+        $result = $this->resultMockFactory->make();
         $feed = $result->getFeed();
         $feed->setLastModified(new \DateTime('@3'));
 
@@ -54,17 +56,5 @@ class HttpLastModifiedTest extends TestCase
         $this->object->correct($result);
 
         $this->assertEquals(new \DateTime('@3'), $feed->getLastModified());
-    }
-
-    protected function getResultMock(): Result
-    {
-        /** @var Document $document */
-        $document = $this->createMock(Document::class);
-        /** @var Feed $feed */
-        $feed = new Feed();
-        /** @var ResponseInterface $response */
-        $response = new NullResponse();
-
-        return new Result($document, $feed, new \DateTime('@0'), $response, 'http://localhost/test.rss');
     }
 }

--- a/tests/FeedIo/Reader/Fixer/LastModifiedTest.php
+++ b/tests/FeedIo/Reader/Fixer/LastModifiedTest.php
@@ -10,12 +10,9 @@
 
 namespace FeedIo\Reader\Fixer;
 
-use FeedIo\Adapter\NullResponse;
-use FeedIo\Adapter\ResponseInterface;
 use FeedIo\Feed;
 use FeedIo\Feed\Item;
-use FeedIo\Reader\Document;
-use FeedIo\Reader\Result;
+use FeedIo\Reader\ResultMockFactory;
 use Psr\Log\NullLogger;
 
 use \PHPUnit\Framework\TestCase;
@@ -33,12 +30,17 @@ class LastModifiedTest extends TestCase
      */
     protected $newest;
 
+    /**
+     * @var ResultMockFactory
+     */
+    protected $resultMockFactory;
+
     protected function setUp()
     {
         $this->newest = new \DateTime('2014-01-01');
-
         $this->object = new LastModified();
         $this->object->setLogger(new NullLogger());
+        $this->resultMockFactory = new ResultMockFactory();
     }
 
     public function testSearchLastModified()
@@ -53,7 +55,7 @@ class LastModifiedTest extends TestCase
 
     public function testCorrect()
     {
-        $result = $this->getResultMock();
+        $result = $this->resultMockFactory->makeWithFeed($this->getFeed());
         $feed = $result->getFeed();
 
         $this->assertNull($feed->getLastModified());
@@ -74,17 +76,5 @@ class LastModifiedTest extends TestCase
         $feed->add($item1)->add($item2);
 
         return $feed;
-    }
-
-    protected function getResultMock(): Result
-    {
-        /** @var Document $document */
-        $document = $this->createMock(Document::class);
-        /** @var Feed $feed */
-        $feed = $this->getFeed();
-        /** @var ResponseInterface $response */
-        $response = new NullResponse();
-
-        return new Result($document, $feed, new \DateTime('@0'), $response, 'http://localhost/test.rss');
     }
 }

--- a/tests/FeedIo/Reader/Fixer/PublicIdTest.php
+++ b/tests/FeedIo/Reader/Fixer/PublicIdTest.php
@@ -10,8 +10,12 @@
 
 namespace FeedIo\Reader\Fixer;
 
+use FeedIo\Adapter\NullResponse;
+use FeedIo\Adapter\ResponseInterface;
 use FeedIo\Feed;
 use FeedIo\Feed\Item;
+use FeedIo\Reader\Document;
+use FeedIo\Reader\Result;
 use Psr\Log\NullLogger;
 
 use \PHPUnit\Framework\TestCase;
@@ -20,7 +24,7 @@ class PublicIdTest extends TestCase
 {
 
     /**
-     * @var FeedIo\Reader\Fixer\PublicId
+     * @var PublicId
      */
     protected $object;
 
@@ -32,10 +36,11 @@ class PublicIdTest extends TestCase
 
     public function testCorrect()
     {
-        $feed = $this->getFeed();
+        $result = $this->getResultMock();
+        $feed = $result->getFeed();
 
         $this->assertNull($feed->getPublicId());
-        $this->object->correct($feed);
+        $this->object->correct($result);
 
         $this->assertEquals($feed->getLink(), $feed->getPublicId());
 
@@ -62,5 +67,17 @@ class PublicIdTest extends TestCase
         $feed->add($item2);
 
         return $feed;
+    }
+
+    protected function getResultMock(): Result
+    {
+        /** @var Document $document */
+        $document = $this->createMock(Document::class);
+        /** @var Feed $feed */
+        $feed = $this->getFeed();
+        /** @var ResponseInterface $response */
+        $response = new NullResponse();
+
+        return new Result($document, $feed, new \DateTime('@0'), $response, 'http://localhost/test.rss');
     }
 }

--- a/tests/FeedIo/Reader/Fixer/PublicIdTest.php
+++ b/tests/FeedIo/Reader/Fixer/PublicIdTest.php
@@ -10,12 +10,9 @@
 
 namespace FeedIo\Reader\Fixer;
 
-use FeedIo\Adapter\NullResponse;
-use FeedIo\Adapter\ResponseInterface;
 use FeedIo\Feed;
 use FeedIo\Feed\Item;
-use FeedIo\Reader\Document;
-use FeedIo\Reader\Result;
+use FeedIo\Reader\ResultMockFactory;
 use Psr\Log\NullLogger;
 
 use \PHPUnit\Framework\TestCase;
@@ -28,15 +25,21 @@ class PublicIdTest extends TestCase
      */
     protected $object;
 
+    /**
+     * @var ResultMockFactory
+     */
+    protected $resultMockFactory;
+
     protected function setUp()
     {
         $this->object = new PublicId();
         $this->object->setLogger(new NullLogger());
+        $this->resultMockFactory = new ResultMockFactory();
     }
 
     public function testCorrect()
     {
-        $result = $this->getResultMock();
+        $result = $this->resultMockFactory->makeWithFeed($this->getFeed());
         $feed = $result->getFeed();
 
         $this->assertNull($feed->getPublicId());
@@ -67,17 +70,5 @@ class PublicIdTest extends TestCase
         $feed->add($item2);
 
         return $feed;
-    }
-
-    protected function getResultMock(): Result
-    {
-        /** @var Document $document */
-        $document = $this->createMock(Document::class);
-        /** @var Feed $feed */
-        $feed = $this->getFeed();
-        /** @var ResponseInterface $response */
-        $response = new NullResponse();
-
-        return new Result($document, $feed, new \DateTime('@0'), $response, 'http://localhost/test.rss');
     }
 }

--- a/tests/FeedIo/Reader/FixerMock.php
+++ b/tests/FeedIo/Reader/FixerMock.php
@@ -32,11 +32,12 @@ class FixerMock extends FixerAbstract
     }
 
     /**
-     * @param  FeedInterface $feed
+     * @param  Result $result
      * @return $this
      */
-    public function correct(FeedInterface $feed) : FixerAbstract
+    public function correct(Result $result) : FixerAbstract
     {
+        $feed = $result->getFeed();
         $feed->setTitle('corrected');
 
         return $this;

--- a/tests/FeedIo/Reader/FixerSetTest.php
+++ b/tests/FeedIo/Reader/FixerSetTest.php
@@ -10,37 +10,31 @@
 
 namespace FeedIo\Reader;
 
-use FeedIo\Adapter\NullResponse;
-use FeedIo\Adapter\ResponseInterface;
-use FeedIo\Feed;
-
 use \PHPUnit\Framework\TestCase;
 
 class FixerSetTest extends TestCase
 {
+    /**
+     * @var ResultMockFactory
+     */
+    protected $resultMockFactory;
+
+    protected function setUp()
+    {
+        $this->resultMockFactory = new ResultMockFactory();
+    }
+
     public function testCorrect()
     {
         $fixer = new FixerMock();
         $fixerSet = new FixerSet();
         $fixerSet->add($fixer);
 
-        $result = $this->getResultMock();
+        $result = $this->resultMockFactory->make();
         $feed = $result->getFeed();
 
         $fixerSet->correct($result);
 
         $this->assertEquals('corrected', $feed->getTitle());
-    }
-
-    protected function getResultMock(): Result
-    {
-        /** @var Document $document */
-        $document = $this->createMock(Document::class);
-        /** @var Feed $feed */
-        $feed =  new Feed();
-        /** @var ResponseInterface $response */
-        $response = new NullResponse();
-
-        return new Result($document, $feed, new \DateTime('@0'), $response, 'http://localhost/test.rss');
     }
 }

--- a/tests/FeedIo/Reader/FixerSetTest.php
+++ b/tests/FeedIo/Reader/FixerSetTest.php
@@ -10,6 +10,8 @@
 
 namespace FeedIo\Reader;
 
+use FeedIo\Adapter\NullResponse;
+use FeedIo\Adapter\ResponseInterface;
 use FeedIo\Feed;
 
 use \PHPUnit\Framework\TestCase;
@@ -22,9 +24,23 @@ class FixerSetTest extends TestCase
         $fixerSet = new FixerSet();
         $fixerSet->add($fixer);
 
-        $feed = new Feed();
-        $fixerSet->correct($feed);
+        $result = $this->getResultMock();
+        $feed = $result->getFeed();
+
+        $fixerSet->correct($result);
 
         $this->assertEquals('corrected', $feed->getTitle());
+    }
+
+    protected function getResultMock(): Result
+    {
+        /** @var Document $document */
+        $document = $this->createMock(Document::class);
+        /** @var Feed $feed */
+        $feed =  new Feed();
+        /** @var ResponseInterface $response */
+        $response = new NullResponse();
+
+        return new Result($document, $feed, new \DateTime('@0'), $response, 'http://localhost/test.rss');
     }
 }

--- a/tests/FeedIo/Reader/ResultMockFactory.php
+++ b/tests/FeedIo/Reader/ResultMockFactory.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * This file is part of the feed-io package.
+ *
+ * (c) Alexandre Debril <alex.debril@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FeedIo\Reader;
+
+use FeedIo\Adapter\NullResponse;
+use FeedIo\Adapter\ResponseInterface;
+use FeedIo\Feed;
+
+class ResultMockFactory
+{
+    public function make(): Result
+    {
+        return $this->makeWithFeed(new Feed());
+    }
+
+    public function makeWithFeed(Feed $feed): Result
+    {
+        /** @var Document $document */
+        $document = new Document('');
+        /** @var ResponseInterface $response */
+        $response = new NullResponse();
+
+        return new Result($document, $feed, new \DateTime('@0'), $response, 'http://localhost/test.rss');
+    }
+}


### PR DESCRIPTION
Found while looking into: https://github.com/nextcloud/news/issues/607
Here is a minimal working example: https://github.com/kesselb/fefe-feed-io

This patch will read the last modified value from the response and pass it to the feed. The last modified fixer will usually workaround this issue for feeds with pub date for the items.
