### PR TITLE
A item without pubDate seems to be valid.

### DIFF
--- a/src/FeedIo/Filter/ModifiedSince.php
+++ b/src/FeedIo/Filter/ModifiedSince.php
@@ -40,6 +40,6 @@ class ModifiedSince implements FilterInterface
             return $item->getLastModified() > $this->date;
         }
 
-        return false;
+        return true;
     }
 }

--- a/tests/FeedIo/Filter/ModifiedSinceTest.php
+++ b/tests/FeedIo/Filter/ModifiedSinceTest.php
@@ -45,6 +45,6 @@ class ModifiedSinceTest extends TestCase
     public function testIsNotValid()
     {
         $item = new Item();
-        $this->assertFalse($this->object->isValid($item));
+        $this->assertTrue($this->object->isValid($item));
     }
 }


### PR DESCRIPTION
That's somehow a regression of https://github.com/alexdebril/feed-io/pull/259

Before #259 last modified was not available. Now we send the right last modified and the server seems to respond accordingly. But for some feeds no items are added.

https://github.com/alexdebril/feed-io/blob/c651b6fc8952ebf0121bc0cc06ceeb3a69d482cf/src/FeedIo/FeedIo.php#L317-L319

A DateTime object for `$modifiedSince` will add the modified since filter.

https://github.com/alexdebril/feed-io/blob/c651b6fc8952ebf0121bc0cc06ceeb3a69d482cf/src/FeedIo/Filter/ModifiedSince.php#L37-L44

Filter will return true if pubDate (or lastBuildDate or lastPubDate) are greater then `$modifiedSince` and false otherwise. As per https://validator.w3.org/feed/docs/rss2.html seems to be a optional property.

Steps to reproduce with nextcloud/news: https://github.com/nextcloud/news/issues/607#issuecomment-578410123 Let me know if you need a minimal working example.