### PR TITLE
Fix hard error on createResponse when feed has no lastModifiedDate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "php": ">=7.1",
         "guzzlehttp/guzzle": "~6.2",
         "psr/log": "~1.0",
-        "symfony/console": "~3.4|~4.0|~5.0"
+        "symfony/console": "~3.4|~4.0|~5.0",
+        "ext-dom": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1552eddc71002cff2afdb9941df2b35b",
+    "content-hash": "58f02fc17ed2bb2d375969e21f71f37f",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -3102,7 +3102,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "ext-dom": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/src/FeedIo/Http/ResponseBuilder.php
+++ b/src/FeedIo/Http/ResponseBuilder.php
@@ -47,10 +47,14 @@ class ResponseBuilder
     public function createResponse(string $format, FormatterInterface $formatter, FeedInterface $feed) : ResponseInterface
     {
         $headers = [
-            'Content-Type' => ($format === 'json') ? 'application/json':'application/xhtml+xml',
-            'Cache-Control' => ($this->public ? 'public':'private') . ", max-age={$this->maxAge}",
-            'Last-Modified' => $feed->getLastModified()->format(\DateTime::RSS),
+            'Content-Type'  => ($format === 'json') ? 'application/json' : 'application/xhtml+xml',
+            'Cache-Control' => ($this->public ? 'public' : 'private') . ", max-age={$this->maxAge}",
         ];
+
+        // Feed could have no items
+        if ($feed->getLastModified() instanceof \DateTime) {
+            $headers['Last-Modified'] = $feed->getLastModified()->format(\DateTime::RSS);
+        }
 
         return new Response(200, $headers, $formatter->toString($feed));
     }

--- a/tests/FeedIo/Http/ResponseBuilderTest.php
+++ b/tests/FeedIo/Http/ResponseBuilderTest.php
@@ -64,7 +64,9 @@ class ResponseBuilderTest extends TestCase
         $response = $responseBuilder->createResponse('atom', $formatter, $feed);
 
         $headers = $response->getHeaders();
-        $this->assertEquals(['Content-Type', 'Cache-Control'], array_keys($headers));
+        $headerNames = array_keys($headers);
+        $this->assertEquals(['Content-Type', 'Cache-Control'], $headerNames);
+        $this->assertArrayNotHasKey('Last-Modified', $headerNames);
         $this->assertEquals('application/xhtml+xml', $headers['Content-Type'][0]);
 
         $body = $response->getBody()->getContents();


### PR DESCRIPTION
Fixes `Call to a member function format() on null` on `ResponseBuilder::createResponse` when the given feed is empty (see error below on symfony app).

Also a few other small inspection fixes on the test file the new test is at.

  * Fix `ResponseBuilder::createResponse` error when feed has no last modified (eg feed is new)
  * Require `ext-dom` in composer as we use it explicitly
  * Remove assertions that `createResponse` returns a psr response object: the method signature already enforces this (`createResponse([...]) : ResponseInterface`)
  * phpunit already has an assertion to check a string is json, no need to use `assertInternalType` which is also deprecated

![image](https://user-images.githubusercontent.com/6388823/82463378-aa4a2c80-9ab4-11ea-9ac4-709674280fdf.png)
