### PR TITLE
Fix Author for namespaced Atom

### DIFF
--- a/src/FeedIo/RuleAbstract.php
+++ b/src/FeedIo/RuleAbstract.php
@@ -54,12 +54,16 @@ abstract class RuleAbstract
     /**
      * @param  \DOMElement $element
      * @param  string      $name
-     * @param  string      $ns
+     * @param  string|null $ns
      * @return string|null
      */
-    public function getChildValue(\DOMElement $element, string $name, string $ns = "") : ? string
+    public function getChildValue(\DOMElement $element, string $name, ?string $ns = null) : ? string
     {
-        $list = $element->getElementsByTagNameNS($ns, $name);
+        if ($ns === null) {
+            $list = $element->getElementsByTagName($name);
+        } else {
+            $list = $element->getElementsByTagNameNS($ns, $name);
+        }
         if ($list->length > 0) {
             return $list->item(0)->nodeValue;
         }
@@ -71,12 +75,16 @@ abstract class RuleAbstract
      * @param  \DOMElement $element
      * @param  string      $child_name
      * @param  string      $attribute_name
-     * @param  string      $ns
+     * @param  string|null $ns
      * @return string|null
      */
-    public function getChildAttributeValue(\DOMElement $element, string $child_name, string $attribute_name, string $ns = "") : ? string
+    public function getChildAttributeValue(\DOMElement $element, string $child_name, string $attribute_name, ?string $ns = null) : ? string
     {
-        $list = $element->getElementsByTagNameNS($ns, $child_name);
+        if ($ns === null) {
+            $list = $element->getElementsByTagName($child_name);
+        } else {
+            $list = $element->getElementsByTagNameNS($ns, $child_name);
+        }
         if ($list->length > 0) {
             return $list->item(0)->getAttribute($attribute_name);
         }

--- a/tests/FeedIo/Rule/Atom/AuthorTest.php
+++ b/tests/FeedIo/Rule/Atom/AuthorTest.php
@@ -45,6 +45,25 @@ class AuthorTest extends TestCase
         $this->assertEquals('john@localhost', $item->getAuthor()->getEmail());
     }
 
+    public function testNamespacedSet()
+    {
+        $item = new Item();
+
+        $ns = 'http://www.w3.org/2005/Atom';
+        $document = \DOMImplementation::createDocument($ns, 'feed');
+
+        $author = $document->createElementNS($ns, 'author');
+
+        $author->appendChild($document->createElementNS($ns, 'name', 'John Doe'));
+        $author->appendChild($document->createElementNS($ns, 'uri', 'http://localhost'));
+        $author->appendChild($document->createElementNS($ns, 'email', 'john@localhost'));
+
+        $this->object->setProperty($item, $author);
+        $this->assertEquals('John Doe', $item->getAuthor()->getName());
+        $this->assertEquals('http://localhost', $item->getAuthor()->getUri());
+        $this->assertEquals('john@localhost', $item->getAuthor()->getEmail());
+    }
+
     public function testGetChildValue()
     {
         $document = new \DOMDocument();


### PR DESCRIPTION
Currently if you try to load feeds from Atom which has namespace like 

```xml
<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
  <author>
    <name>Example</name>
  </author>
</feed>
```

It will return `null` for Author fields because it looks in empty `''` namespace.
This PR fixes that.
