### PR TITLE
Implement recursive toArray

### DIFF
--- a/src/FeedIo/Feed.php
+++ b/src/FeedIo/Feed.php
@@ -13,8 +13,9 @@ namespace FeedIo;
 use FeedIo\Feed\Node;
 use FeedIo\Feed\Item;
 use FeedIo\Feed\ItemInterface;
+use FeedIo\Feed\ArrayableInterface;
 
-class Feed extends Node implements FeedInterface, \JsonSerializable
+class Feed extends Node implements FeedInterface, ArrayableInterface, \JsonSerializable
 {
     /**
      * @var \ArrayIterator

--- a/src/FeedIo/Feed/ArrayableInterface.php
+++ b/src/FeedIo/Feed/ArrayableInterface.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace FeedIo\Feed;
+
+interface ArrayableInterface
+{
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray();
+}

--- a/src/FeedIo/Feed/Item/Author.php
+++ b/src/FeedIo/Feed/Item/Author.php
@@ -10,7 +10,9 @@
 
 namespace FeedIo\Feed\Item;
 
-class Author implements AuthorInterface
+use FeedIo\Feed\ArrayableInterface;
+
+class Author implements AuthorInterface, ArrayableInterface
 {
 
     /**
@@ -83,5 +85,13 @@ class Author implements AuthorInterface
         $this->email = $email;
 
         return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray() : array
+    {
+        return get_object_vars($this);
     }
 }

--- a/src/FeedIo/Feed/Item/Media.php
+++ b/src/FeedIo/Feed/Item/Media.php
@@ -10,7 +10,9 @@
 
 namespace FeedIo\Feed\Item;
 
-class Media implements MediaInterface
+use FeedIo\Feed\ArrayableInterface;
+
+class Media implements MediaInterface, ArrayableInterface
 {
     /**
      * @var string
@@ -190,5 +192,13 @@ class Media implements MediaInterface
         $this->thumbnail = $thumbnail;
 
         return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray() : array
+    {
+        return get_object_vars($this);
     }
 }

--- a/tests/FeedIo/Feed/ItemTest.php
+++ b/tests/FeedIo/Feed/ItemTest.php
@@ -170,4 +170,33 @@ class ItemTest extends TestCase
     {
         $this->assertInstanceOf('\FeedIo\Feed\Item\AuthorInterface', $this->object->newAuthor());
     }
+
+    public function testToArray()
+    {
+        $author = new Author();
+        $author->setName('test');
+        $author->setEmail('test@example.org');
+        $author->setUri('http://example.org/');
+        $this->object->setAuthor($author);
+
+        $media = new Media();
+        $media->setType('audio/mp3');
+        $media->setTitle('Media');
+        $media->setUrl('http://example.org/media.mp3');
+        $this->object->addMedia($media);
+
+        $out = $this->object->toArray();
+
+        $this->assertEquals(['name'  => 'test',
+                             'email' => 'test@example.org',
+                             'uri'   => 'http://example.org/'], $out['author']);
+
+        $this->assertEquals([['type'  => 'audio/mp3',
+                              'url'   => 'http://example.org/media.mp3',
+                              'title'       => 'Media',
+                              'description' => null,
+                              'thumbnail'   => null,
+                              'length'      => null,
+                              'nodeName'    => null]], $out['medias']);
+    }
 }

--- a/tests/FeedIo/JsonFormatterTest.php
+++ b/tests/FeedIo/JsonFormatterTest.php
@@ -51,6 +51,8 @@ class JsonFormatterTest extends TestCase
             $this->assertArrayHasKey('author', $item);
             $this->assertArrayHasKey('date_published', $item);
         }
+
+        $this->assertEquals(['name' => 'foo bar'], $json['items'][0]['author']);
     }
 
     public function testIsHtml()

--- a/tests/FeedIo/Parser/JsonParserTest.php
+++ b/tests/FeedIo/Parser/JsonParserTest.php
@@ -43,12 +43,12 @@ class JsonParserTest extends TestCase
         $this->assertNull($items[0]['author']);
         $this->assertNull($items[1]['author']);
 
-        $this->assertEquals('Manton Reece', $items[2]['author']->getName());
-        $this->assertNull($items[2]['author']->getUri());
-        $this->assertNull($items[2]['author']->getEmail());
+        $this->assertEquals('Manton Reece', $items[2]['author']['name']);
+        $this->assertNull($items[2]['author']['uri']);
+        $this->assertNull($items[2]['author']['email']);
 
-        $this->assertEquals('Manton Reece', $items[3]['author']->getName());
-        $this->assertEquals('http://manton.org', $items[3]['author']->getUri());
-        $this->assertEquals('manton@micro.blog', $items[3]['author']->getEmail());
+        $this->assertEquals('Manton Reece', $items[3]['author']['name']);
+        $this->assertEquals('http://manton.org', $items[3]['author']['uri']);
+        $this->assertEquals('manton@micro.blog', $items[3]['author']['email']);
     }
 }


### PR DESCRIPTION
Currently `$feed->toArray()` would make array only first level and would leave `Author` still as object. This is not good when you want to serialize it in some format because then you would need to know about it's internal structure. This PR changes that so it's converted to array recursively including all nested objects. This allows to serialize a feed very easily, eg. `serialize($feed->toArray())`

