### PR TITLE
Make sure to restore the error handler

### DIFF
--- a/src/FeedIo/Reader/Document.php
+++ b/src/FeedIo/Reader/Document.php
@@ -68,9 +68,12 @@ class Document
             }
         );
 
-        $domDocument = new \DOMDocument();
-        $domDocument->loadXML($this->content);
-        restore_error_handler();
+        try {
+            $domDocument = new \DOMDocument();
+            $domDocument->loadXML($this->content);
+        } finally {
+            restore_error_handler();
+        }
 
         return $domDocument;
     }


### PR DESCRIPTION
When the `InvalidArgumentException` thrown by the error handler gets caught, the error handler will never be restored which results in weird error messages for any following error. By using `try ... finally` the handler wil be restored in either case.