### PR TITLE
Set `language` attribute instead of feeding the dyn array

### DIFF
--- a/src/FeedIo/Rule/Language.php
+++ b/src/FeedIo/Rule/Language.php
@@ -25,7 +25,7 @@ class Language extends RuleAbstract
     public function setProperty(NodeInterface $node, \DOMElement $element): void
     {
         if ($node instanceof FeedInterface) {
-            $node->set(static::NODE_NAME, $element->nodeValue);
+            $node->setLanguage($element->nodeValue);
         }
     }
 


### PR DESCRIPTION
close #362 