### PR TITLE
Added more consice mime types to default standards

### DIFF
--- a/src/FeedIo/FeedIo.php
+++ b/src/FeedIo/FeedIo.php
@@ -143,10 +143,10 @@ class FeedIo
     {
         $this->logAction($feed, "creating a PSR 7 Response in $standard format");
 
-        $formatter = $this->specification->getStandard($standard)->getFormatter();
+        $feedStandard = $this->specification->getStandard($standard);
         $responseBuilder = new ResponseBuilder($maxAge, $public);
 
-        return $responseBuilder->createResponse($standard, $formatter, $feed);
+        return $responseBuilder->createResponse($feedStandard->getMimeType(), $feedStandard->getFormatter(), $feed);
     }
 
     /**

--- a/src/FeedIo/Http/ResponseBuilder.php
+++ b/src/FeedIo/Http/ResponseBuilder.php
@@ -22,15 +22,15 @@ class ResponseBuilder
     }
 
     /**
-     * @param  string $format
+     * @param  string $mimeType
      * @param  FormatterInterface $formatter
      * @param  FeedInterface $feed
      * @return ResponseInterface
      */
-    public function createResponse(string $format, FormatterInterface $formatter, FeedInterface $feed): ResponseInterface
+    public function createResponse(string $mimeType, FormatterInterface $formatter, FeedInterface $feed): ResponseInterface
     {
         $headers = [
-            'Content-Type'  => ($format === 'json') ? 'application/json' : 'application/xhtml+xml',
+            'Content-Type'  => $mimeType,
             'Cache-Control' => ($this->public ? 'public' : 'private') . ", max-age={$this->maxAge}",
         ];
 

--- a/src/FeedIo/Standard/Atom.php
+++ b/src/FeedIo/Standard/Atom.php
@@ -26,6 +26,8 @@ class Atom extends XmlAbstract
 
     public const DATETIME_FORMAT = \DateTime::ATOM;
 
+    public const MIME_TYPE = 'application/atom+xml';
+
     public function format(DOMDocument $document): DOMDocument
     {
         $element = $document->createElement('feed');

--- a/src/FeedIo/Standard/Json.php
+++ b/src/FeedIo/Standard/Json.php
@@ -13,6 +13,8 @@ class Json extends StandardAbstract
 {
     public const SYNTAX_FORMAT = 'Json';
 
+    public const MIME_TYPE = 'application/feed+json';
+
     protected array $mandatoryFields = ['version', 'title', 'items'];
 
     /**

--- a/src/FeedIo/Standard/Rdf.php
+++ b/src/FeedIo/Standard/Rdf.php
@@ -27,6 +27,8 @@ class Rdf extends Rss
      */
     public const DATE_NODE_TAGNAME = 'dc:date';
 
+    public const MIME_TYPE = 'application/rdf+xml';
+
     /**
      * Tells if the parser can handle the feed or not
      * @param  Document $document

--- a/src/FeedIo/Standard/Rss.php
+++ b/src/FeedIo/Standard/Rss.php
@@ -40,6 +40,8 @@ class Rss extends XmlAbstract
      */
     public const DATE_NODE_TAGNAME = 'pubDate';
 
+    public const MIME_TYPE = 'application/rss+xml';
+
     protected array $mandatoryFields = ['channel'];
 
     /**

--- a/src/FeedIo/StandardAbstract.php
+++ b/src/FeedIo/StandardAbstract.php
@@ -16,6 +16,11 @@ abstract class StandardAbstract
     public const DATETIME_FORMAT = \DateTime::RFC2822;
 
     /**
+     * Standard mime type
+     */
+    public const MIME_TYPE = '';
+
+    /**
      * Supported format
      */
     public const SYNTAX_FORMAT = '';
@@ -62,5 +67,14 @@ abstract class StandardAbstract
     public function getSyntaxFormat(): string
     {
         return static::SYNTAX_FORMAT;
+    }
+
+    /**
+     * Returns the mime type for the standard
+     * @return string
+     */
+    public function getMimeType(): string
+    {
+        return static::MIME_TYPE;
     }
 }

--- a/tests/FeedIo/Http/ResponseBuilderTest.php
+++ b/tests/FeedIo/Http/ResponseBuilderTest.php
@@ -19,11 +19,11 @@ class ResponseBuilderTest extends TestCase
         $formatter = new JsonFormatter();
         $feed = $this->getFeed();
 
-        $response = $responseBuilder->createResponse('json', $formatter, $feed);
+        $response = $responseBuilder->createResponse('application/feed+json', $formatter, $feed);
 
         $headers = $response->getHeaders();
         $this->assertEquals(['Content-Type', 'Cache-Control', 'Last-Modified'], array_keys($headers));
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+        $this->assertEquals('application/feed+json', $headers['Content-Type'][0]);
 
         $body = $response->getBody()->getContents();
         $this->assertJson($body);
@@ -37,11 +37,11 @@ class ResponseBuilderTest extends TestCase
         $formatter = new XmlFormatter(new Atom($dateTimeBuilder));
         $feed = $this->getFeed();
 
-        $response = $responseBuilder->createResponse('atom', $formatter, $feed);
+        $response = $responseBuilder->createResponse('application/atom+xml', $formatter, $feed);
 
         $headers = $response->getHeaders();
         $this->assertEquals(['Content-Type', 'Cache-Control', 'Last-Modified'], array_keys($headers));
-        $this->assertEquals('application/xhtml+xml', $headers['Content-Type'][0]);
+        $this->assertEquals('application/atom+xml', $headers['Content-Type'][0]);
 
         $body = $response->getBody()->getContents();
         $document = new \DOMDocument();
@@ -62,13 +62,13 @@ class ResponseBuilderTest extends TestCase
         $feed->setUrl('http://localhost');
         $feed->setTitle('test feed');
 
-        $response = $responseBuilder->createResponse('atom', $formatter, $feed);
+        $response = $responseBuilder->createResponse('application/atom+xml', $formatter, $feed);
 
         $headers = $response->getHeaders();
         $headerNames = array_keys($headers);
         $this->assertEquals(['Content-Type', 'Cache-Control'], $headerNames);
         $this->assertArrayNotHasKey('Last-Modified', $headerNames);
-        $this->assertEquals('application/xhtml+xml', $headers['Content-Type'][0]);
+        $this->assertEquals('application/atom+xml', $headers['Content-Type'][0]);
 
         $body = $response->getBody()->getContents();
         $document = new \DOMDocument();


### PR DESCRIPTION
This is the PR for #393 

I ended up adding the mime type to the standard and then passing it from there directly to the response builder. The advantage being that any custom standard will be supported. It is a breaking change though. Alternatively, I could just resubmit a PR with just a regular match statement within `ResponseBuilder::createResponse()`.