### PR TITLE
Improve handling of feeds when discover encounters feed links without protocol

### DIFF
--- a/src/FeedIo/Explorer.php
+++ b/src/FeedIo/Explorer.php
@@ -45,7 +45,15 @@ class Explorer
         $feeds = [];
         foreach ($links as $link) {
             if ($this->isFeedLink($link)) {
-                $feeds[] = $link->getAttribute('href');
+                $href = $link->getAttribute('href');
+                if (strpos($href, '//') === 0) {
+                    // Link href is protocol-less, Implies feed supports http
+                    // and https. Consumers will often assume that feed url
+                    // includes protocol, so we will assign a protocol before
+                    // returning
+                    $href = 'https:' . $href;
+                }
+                $feeds[] = $href;
             }
         }
 

--- a/tests/FeedIo/ExplorerTest.php
+++ b/tests/FeedIo/ExplorerTest.php
@@ -27,8 +27,13 @@ class ExplorerTest extends TestCase
 
     public function setUp(): void
     {
+        
+    }
+
+    protected function createTestObject(string $htmlPath)
+    {
         $this->object = new Explorer(
-            $this->getClientMock(),
+            $this->getClientMock($htmlPath),
             new NullLogger()
         );
     }
@@ -36,9 +41,9 @@ class ExplorerTest extends TestCase
     /**
      * @return \FeedIo\Adapter\ClientInterface
      */
-    protected function getClientMock()
+    protected function getClientMock(string $htmlPath)
     {
-        $html = file_get_contents(dirname(__FILE__)."/../samples/discovery.html");
+        $html = file_get_contents(dirname(__FILE__) . $htmlPath);
         $client = $this->createMock('FeedIo\Adapter\ClientInterface');
         $response = $this->createMock('FeedIo\Adapter\ResponseInterface');
         $response->expects($this->any())->method('getBody')->will($this->returnValue($html));
@@ -52,8 +57,31 @@ class ExplorerTest extends TestCase
      */
     public function testDiscover()
     {
+        $this->createTestObject("/../samples/discovery.html");
         $feeds = $this->object->discover('https://exmple.org/feed.atom');
 
         $this->assertEquals(['http://example.org/feed.xml', 'http://example.org/comments.xml'], $feeds);
+    }
+
+    /**
+     * @covers \FeedIo\Reader::addParser
+     */
+    public function testDiscoverHttps()
+    {
+        $this->createTestObject("/../samples/discovery-https.html");
+        $feeds = $this->object->discover('https://exmple.org/feed.atom');
+
+        $this->assertEquals(['https://example.org/feed.xml', 'https://example.org/comments.xml'], $feeds);
+    }
+
+    /**
+     * @covers \FeedIo\Reader::addParser
+     */
+    public function testDiscoverProtocolless()
+    {
+        $this->createTestObject("/../samples/discovery-mixed.html");
+        $feeds = $this->object->discover('https://exmple.org/feed.atom');
+
+        $this->assertEquals(['https://example.org/feed.xml', 'https://example.org/comments.xml'], $feeds);
     }
 }

--- a/tests/samples/discovery-dualprotocol.html
+++ b/tests/samples/discovery-dualprotocol.html
@@ -1,0 +1,16 @@
+<html>
+    <head>
+
+         <link rel="shortcut icon" href="/favicon.ico">
+         <link rel="search" type="application/opensearchdescription+xml" href="/improvedsearch.src" title="Add search">
+         <link rel="alternate" type="application/atom+xml" href="//example.org/feed.xml" title="Main feed">
+         <link rel="alternate" type="application/atom+xml" href="//example.org/comments.xml" title="Comments feed">
+
+         <link rel="canonical" href="//example.org/index.php">
+         <link rel="shorturl" href="//example.org/index">
+         <link rel="alternate" href="//example.org/index" hreflang="x-default">
+
+        <link rel="stylesheet" type="text/css" href="//example.org/styles/home.css" media="screen">
+    </head>
+    <body></body>
+</html>

--- a/tests/samples/discovery-https.html
+++ b/tests/samples/discovery-https.html
@@ -1,0 +1,16 @@
+<html>
+    <head>
+
+         <link rel="shortcut icon" href="/favicon.ico">
+         <link rel="search" type="application/opensearchdescription+xml" href="/improvedsearch.src" title="Add search">
+         <link rel="alternate" type="application/atom+xml" href="https://example.org/feed.xml" title="Main feed">
+         <link rel="alternate" type="application/atom+xml" href="https://example.org/comments.xml" title="Comments feed">
+
+         <link rel="canonical" href="https://example.org/index.php">
+         <link rel="shorturl" href="https://example.org/index">
+         <link rel="alternate" href="https://example.org/index" hreflang="x-default">
+
+        <link rel="stylesheet" type="text/css" href="https://example.org/styles/home.css" media="screen">
+    </head>
+    <body></body>
+</html>


### PR DESCRIPTION
Some websites will omit the http/https protocol from links within the document, allowing the browser to request the feed via http or https depending on which protocol the page itself was fetched via. 

The discover functionality of FeedIO does not apply a protocol to such links, but downstream consumers, such as Nextcloud news, will assume that discovered feeds include the protocol.

This commit alters FeedIO so that it assigns the https protocol to such discovered feeds that do not include the protocol in their link, allowing downstream consumers to maintain their assumption that discovered feeds will include a feed without breaking compatibility with the source feed, unless the source feed violates the assumption that a link href that omits the protocol can be fetched via either http or https, which is an assumption that should be out of scope for FeedIO, yes?

Signed-off-by: Accalia <Accalia@Elementia.me>