### PR TITLE
Workaround for atom-like links in RSS feeds

### DIFF
--- a/src/FeedIo/Rule/Link.php
+++ b/src/FeedIo/Rule/Link.php
@@ -23,7 +23,13 @@ class Link extends RuleAbstract
      */
     public function setProperty(NodeInterface $node, \DOMElement $element) : void
     {
-        $node->setLink($element->nodeValue);
+        if (is_null($element->nodeValue) || $element->nodeValue == '') {
+            if ($element->hasAttribute('rel') && $element->getAttribute('rel') == 'alternate') {
+                $node->setLink($element->getAttribute('href'));
+            }
+        } else {
+            $node->setLink($element->nodeValue);
+        }
     }
 
     /**


### PR DESCRIPTION
Some RSS feeds specify links using an atom-like format, specifically as `<link rel="alternate" type="text/html" href="URL"></link>`
This PR attempts to add support for reading such links.