### PR TITLE
Fix: Release/5.3.x Support relative links

### DIFF
--- a/src/FeedIo/Explorer.php
+++ b/src/FeedIo/Explorer.php
@@ -29,14 +29,14 @@ class Explorer
         $stream = $this->client->getResponse($url, new DateTime('@0'));
 
         $internalErrors = libxml_use_internal_errors(true);
-        $feeds = $this->extractFeeds($stream->getBody());
+        $feeds = $this->extractFeeds($stream->getBody(), $url);
 
         libxml_use_internal_errors($internalErrors);
 
         return $feeds;
     }
 
-    protected function extractFeeds(string $html): array
+    protected function extractFeeds(string $html, string $url = null): array    
     {
         $dom = new DOMDocument();
         $dom->loadHTML($html);
@@ -52,6 +52,9 @@ class Explorer
                     // includes protocol, so we will assign a protocol before
                     // returning
                     $href = 'https:' . $href;
+                }
+                if (!parse_url($href, PHP_URL_HOST) && $url){
+                    $href = parse_url($url, PHP_URL_SCHEME) . '://' . parse_url($url, PHP_URL_HOST) . '/' . ltrim($href,'/');
                 }
                 $feeds[] = $href;
             }

--- a/src/FeedIo/Feed.php
+++ b/src/FeedIo/Feed.php
@@ -134,6 +134,8 @@ class Feed extends Node implements FeedInterface, ArrayableInterface, \JsonSeria
 
     public function add(ItemInterface $item): FeedInterface
     {
+        $item->setHostInContent($this->getHostFromLink());
+
         if ($item->getLastModified() > $this->getLastModified()) {
             $this->setLastModified($item->getLastModified());
         }

--- a/src/FeedIo/Feed/Node.php
+++ b/src/FeedIo/Feed/Node.php
@@ -150,6 +150,33 @@ class Node implements NodeInterface, ElementsAwareInterface, ArrayableInterface
         }
     }
 
+    protected function setHostInContent(string $host = null): void
+    {
+        if (property_exists($this, 'content')){
+            if (!is_null($host) && !is_null($this->content)) {
+                $this->content = preg_replace('!(<*\s*[^>]*)(href=)(.?)(\/[^\/])!','\1 href=\3'.$host.'\4', $this->content );
+                $this->content = preg_replace('!(<*\s*[^>]*)(src=)(.?)(\/[^\/])!','\1 src=\3'.$host.'\4', $this->content );
+            }
+        }
+        if (property_exists($this, 'description')){
+            if (!is_null($host) && !is_null($this->description)) {
+                $this->description = preg_replace('!(<*\s*[^>]*)(href=)(.?)(\/[^\/])!','\1 href=\3'.$host.'\4', $this->description );
+                $this->description = preg_replace('!(<*\s*[^>]*)(src=)(.?)(\/[^\/])!','\1 src=\3'.$host.'\4', $this->description );
+            }
+        }
+    }
+
+    public function getHostFromLink(): ?string
+    {
+        if (!is_null($this->getLink())) {
+            $partsUrl  = parse_url($this->getLink());
+            $result = $partsUrl['scheme']."://".$partsUrl['host'];
+        } else
+            $result = null;
+
+        return $result;
+    }
+
     public function getValue(string $name): ?string
     {
         foreach ($this->getElementIterator($name) as $element) {

--- a/src/FeedIo/Parser/XmlParser.php
+++ b/src/FeedIo/Parser/XmlParser.php
@@ -76,7 +76,8 @@ class XmlParser extends ParserAbstract
     protected function handleNode(NodeInterface $item, DOMElement $node, RuleSet $ruleSet): void
     {
         if ($this->isItem($node->tagName) && $item instanceof FeedInterface) {
-            $newItem = $this->parseNode($item->newItem(), $node, $this->getItemRuleSet());
+            $linkItem = $item->getLink();
+            $newItem = $this->parseNode($item->newItem()->setLink($linkItem), $node, $this->getItemRuleSet());
             $this->addValidItem($item, $newItem);
         } else {
             $rule = $ruleSet->get($node->tagName);

--- a/src/FeedIo/Reader.php
+++ b/src/FeedIo/Reader.php
@@ -73,6 +73,7 @@ class Reader
         try {
             $this->logger->info("hitting {$url}");
             $response = $this->client->getResponse($url, $modifiedSince);
+            $feed->setLink($url);
             $document = $this->handleResponse($response, $feed);
 
             return new Result($document, $feed, $modifiedSince, $response, $url);

--- a/src/FeedIo/Rule/Link.php
+++ b/src/FeedIo/Rule/Link.php
@@ -17,7 +17,11 @@ class Link extends RuleAbstract
      */
     public function setProperty(NodeInterface $node, \DOMElement $element): void
     {
-        $node->setLink($element->nodeValue);
+        $nodeValue = $element->nodeValue;
+        if (parse_url($nodeValue, PHP_URL_HOST) == null) {
+            $nodeValue = $node->getHostFromLink(). $nodeValue;
+        }
+        $node->setLink($nodeValue);
     }
 
     /**


### PR DESCRIPTION
- Fix: feed discovery with relative URLs in links
Example: https://k47.cz/

- Fix: relative links in the Title and in Body
Solution to the problem: 
https://github.com/alexdebril/feed-io/issues/417
https://github.com/alexdebril/feed-io/issues/418
https://github.com/nextcloud/news/issues/1952
https://github.com/nextcloud/news/issues/1605