### PR TITLE
[5.3] If "Link" does not exist, then set it based on "guid"

### DIFF
--- a/src/FeedIo/Rule/PublicId.php
+++ b/src/FeedIo/Rule/PublicId.php
@@ -18,6 +18,11 @@ class PublicId extends RuleAbstract
     public function setProperty(NodeInterface $node, \DOMElement $element): void
     {
         $node->setPublicId($element->nodeValue);
+        if ($element->nodeName == 'guid'
+        && $element->getAttribute('isPermaLink') === 'true'
+        && is_null($node->getLink())) {
+            $node->setLink($element->nodeValue);
+        }
     }
 
     /**


### PR DESCRIPTION
Example: https://k47.cz/rss.xml
RSS 2.0 Specification: https://cyber.harvard.edu/rss/rss.html