### PR TITLE
[5.3] Fix: Analysis of relative links for the Atom feed

### DIFF
--- a/src/FeedIo/Feed/Node.php
+++ b/src/FeedIo/Feed/Node.php
@@ -30,6 +30,8 @@ class Node implements NodeInterface, ElementsAwareInterface, ArrayableInterface
 
     protected ?string $host = null;
 
+    protected ?string $linkLinkForAnalysis = null;
+
     public function __construct()
     {
         $this->initElements();
@@ -135,10 +137,23 @@ class Node implements NodeInterface, ElementsAwareInterface, ArrayableInterface
         return $this->link;
     }
 
+    public function getLinkForAnalysis(): ?string
+    {
+        return $this->linkForAnalysis;
+    }
+
     public function setLink(string $link = null): NodeInterface
     {
         $this->link = $link;
         $this->setHost($link);
+        $this->setLinkForAnalysis($link);
+
+        return $this;
+    }
+
+    public function setLinkForAnalysis(string $link = null): NodeInterface
+    {
+        $this->linkForAnalysis = $link;
 
         return $this;
     }
@@ -160,7 +175,7 @@ class Node implements NodeInterface, ElementsAwareInterface, ArrayableInterface
         $this->pregReplaceInProperty('content', $pattern, '\1\2\3'.$host.'\4');
         $this->pregReplaceInProperty('description', $pattern, '\1\2\3'.$host.'\4');
 
-        $itemFullLink = $this->getLink();
+        $itemFullLink = $this->getLinkForAnalysis();
         $itemLink = implode("/", array_slice(explode("/", $itemFullLink), 0, -1))."/";
 
         // Replaced links like href="#aaa/bbb.xxx"
@@ -183,10 +198,10 @@ class Node implements NodeInterface, ElementsAwareInterface, ArrayableInterface
 
     public function getHostFromLink(): ?string
     {
-        if (is_null($this->getLink())) {
+        if (is_null($this->getLinkForAnalysis())) {
             return null;
         }
-        $partsUrl = parse_url($this->getLink());
+        $partsUrl = parse_url($this->getLinkForAnalysis());
 
         return $partsUrl['scheme']."://".$partsUrl['host'];
     }

--- a/src/FeedIo/Parser/XmlParser.php
+++ b/src/FeedIo/Parser/XmlParser.php
@@ -77,7 +77,8 @@ class XmlParser extends ParserAbstract
     {
         if ($this->isItem($node->tagName) && $item instanceof FeedInterface) {
             $linkItem = $item->getLink();
-            $newItem = $this->parseNode($item->newItem()->setLink($linkItem), $node, $this->getItemRuleSet());
+            $newItem = $this->parseNode($item->newItem()->setLinkForAnalysis($linkItem), $node, $this->getItemRuleSet());
+
             $this->addValidItem($item, $newItem);
         } else {
             $rule = $ruleSet->get($node->tagName);

--- a/src/FeedIo/Rule/Atom/Link.php
+++ b/src/FeedIo/Rule/Atom/Link.php
@@ -28,7 +28,11 @@ class Link extends BaseLink
         ($element->hasAttribute('rel') && $element->getAttribute('rel') == 'alternate')
         || is_null($node->getLink())
         ) {
-            $node->setLink($element->getAttribute('href'));
+            $href = $element->getAttribute('href');
+            if (parse_url($href, PHP_URL_HOST) == null) {
+                $href = $node->getHostFromLink(). $href;
+            }
+            $node->setLink($href);
         }
     }
 


### PR DESCRIPTION
In addition to #422
#422 - partially corrupted the formation of Link for the Atom feed.
I learned about this only the day before yesterday and urgently made this PR.